### PR TITLE
Uncomment "clients" route in routes/login.tsx

### DIFF
--- a/src/pages/login/outlets/Clients/interface.tsx
+++ b/src/pages/login/outlets/Clients/interface.tsx
@@ -44,7 +44,7 @@ function ClientsUI({
 
   return (
     <StyledClients>
-      <Text as="h2" textAlign="center" size="large">
+      <Text type="title" as="h2" textAlign="center">
         Clientes
       </Text>
       <Text size="medium" textAlign="center">

--- a/src/pages/login/outlets/Clients/interface.tsx
+++ b/src/pages/login/outlets/Clients/interface.tsx
@@ -23,10 +23,8 @@ interface ClientsUIProps {
 function NoResultsMessage({ search }: { search: string }) {
   return (
     <StyledNoResults>
-      <Text typo="bodyMedium">
-        No se encontraron resultados para "{search}".
-      </Text>
-      <Text typo="bodyMedium">
+      <Text size="medium">No se encontraron resultados para "{search}".</Text>
+      <Text size="medium">
         Por favor, intenta modificando los parámetros de búsqueda.
       </Text>
     </StyledNoResults>
@@ -46,10 +44,10 @@ function ClientsUI({
 
   return (
     <StyledClients>
-      <Text as="h2" align="center" typo="titleLarge">
+      <Text as="h2" textAlign="center" size="large">
         Clientes
       </Text>
-      <Text typo="bodyMedium" align="center">
+      <Text size="medium" textAlign="center">
         Selecciona la empresa a la que vas a representar
       </Text>
       <form>
@@ -80,11 +78,7 @@ function ClientsUI({
             </StyledClientsItem>
           ))}
         </StyledClientsList>
-        <Button
-          type="button"
-          isDisabled={client.value}
-          handleClick={handleSubmit}
-        >
+        <Button type="button" disabled={client.value} onClick={handleSubmit}>
           Continuar
         </Button>
       </form>

--- a/src/pages/login/outlets/Clients/interface.tsx
+++ b/src/pages/login/outlets/Clients/interface.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MdSearch } from "react-icons/md";
-import { Button, Text, TextField } from "@inube/design-system";
+import { Button, Text, Textfield } from "@inube/design-system";
 import { RadioClient } from "@components/cards/RadioClient";
 import { IClientState, IClient } from "./types";
 import {
@@ -54,15 +54,14 @@ function ClientsUI({
       </Text>
       <form>
         {clients.length > 10 && (
-          <TextField
+          <Textfield
             placeholder="Buscar..."
             type="search"
             name="searchClients"
             id="searchClients"
             value={search}
-            minLength={1}
-            isFullWidth={true}
-            handleChange={handleSearchChange}
+            fullwidth={true}
+            onChange={handleSearchChange}
             iconBefore={<MdSearch size={22} />}
           />
         )}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -15,8 +15,8 @@ function LoginRoutes() {
         path="/:user_id/checking-credentials"
         element={<CheckingCredentials />}
       />
-      {/* <Route path="/:user_id/clients" element={<Clients />} /> */}
-      {/* <Route path="loading-app" element={<LoadingApp />} /> */}
+      <Route path="/:user_id/clients" element={<Clients />} />
+      <Route path="loading-app" element={<LoadingApp />} />
       {/* </Route> */}
       {/* <Route path="error/not-available" element={<ErrorNotAvailable />} /> */}
       {/* <Route path="error/not-related-clients" element={<ErrorNotClient />} /> */}


### PR DESCRIPTION
This PR reintroduces the "clients" route within our application by uncommenting the relevant line of code in routes/login.tsx. This update is a step towards re-enabling full navigational functionality within the application, ensuring that users can access the "clients" section directly from the login routes.