### PR TITLE
Uncomment "error/not-available", "error/not-related-clients" and "/*" in routes/login.tsx

### DIFF
--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -18,9 +18,9 @@ function LoginRoutes() {
       {/* <Route path="/:user_id/clients" element={<Clients />} /> */}
       {/* <Route path="loading-app" element={<LoadingApp />} /> */}
       {/* </Route> */}
-      {/* <Route path="error/not-available" element={<ErrorNotAvailable />} /> */}
-      {/* <Route path="error/not-related-clients" element={<ErrorNotClient />} /> */}
-      {/* <Route path="/*" element={<ErrorPage />} /> */}
+      <Route path="error/not-available" element={<ErrorNotAvailable />} />
+      <Route path="error/not-related-clients" element={<ErrorNotClient />} />
+      <Route path="/*" element={<ErrorPage />} />
     </Routes>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       "@pages": path.resolve(__dirname, "./src/pages"),
       "@styles": path.resolve(__dirname, "./src/styles"),
       "@validations": path.resolve(__dirname, "./src/validations"),
+      "@assets": path.resolve(__dirname, "./src/assets"),
     },
   },
 });


### PR DESCRIPTION
This PR focuses on re-enabling three specific routes in the routes/login.tsx file: "error/not-available", "error/not-related-clients", and "/*". These routes are essential for handling particular error scenarios and providing a fallback for undefined routes. By uncommenting these lines, we aim to restore full navigational functionality and improve error handling within the application.