### PR TITLE
Uncomment  `/*`  route in `routes/privileges.tsx`

### DIFF
--- a/src/routes/privileges.tsx
+++ b/src/routes/privileges.tsx
@@ -20,7 +20,7 @@ function PrivilegesRoutes() {
           element={<CompleteInvitation />}
         /> */}
       {/* </Route> */}
-      {/* <Route path="/*" element={<ErrorPage />} /> */}
+      <Route path="/*" element={<ErrorPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
the privilege path is enabled, although at this moment it directs to the error page, it is verified that the path remains functional.