### PR TITLE
Refactor usage of `<Breadcrumbs />` and `<Grid />`

### DIFF
--- a/src/components/PageTitle/index.tsx
+++ b/src/components/PageTitle/index.tsx
@@ -34,7 +34,9 @@ function PageTitle(props: PageTitleProps) {
               icon={<MdArrowBack />}
               spacing="wide"
               size="24px"
-              onClick={navigatePage ? navigate(navigatePage) : navigate(-1)}
+              onClick={() =>
+                navigatePage ? navigate(navigatePage) : navigate(-1)
+              }
             />
           )}
 

--- a/src/components/cards/AppMenuCard/index.tsx
+++ b/src/components/cards/AppMenuCard/index.tsx
@@ -22,7 +22,7 @@ function AppMenuCard(props: AppMenuCardProps) {
             size="24px"
             shape="circle"
           />
-          <Stack gap="4px" direction="column">
+          <Stack gap="4px" direction="column" width="100%">
             <Text textAlign="center" type="title" size="medium">
               {label}
             </Text>

--- a/src/components/layout/AppMenu/AppMenu.stories.tsx
+++ b/src/components/layout/AppMenu/AppMenu.stories.tsx
@@ -31,7 +31,20 @@ Privileges.args = {
   appName: "Privilegios",
   appDescription: "Modifica las propiedades y permisos de tu cuenta",
   navigatePage: "/",
-  appRoute: "/privileges",
+  appRoute: [
+    {
+      path: "/home",
+      label: "Inicio",
+      id: "/home",
+      isActive: false,
+    },
+    {
+      path: "/home/users",
+      label: "Usuarios",
+      id: "/home/users",
+      isActive: false,
+    },
+  ],
   appOptions: [
     {
       id: 1,

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -1,14 +1,14 @@
 import { AppMenuCard } from "@components/cards/AppMenuCard/index";
-import { Breadcrumbs } from "@inube/design-system";
+import { Breadcrumbs, Grid } from "@inube/design-system";
 import { PageTitle } from "../../PageTitle";
 import { StyledAppMenu, StyledCards, StyledTitle } from "./styles";
-import { IAppOption } from "./types";
+import { IAppMenuProps, IAppOption } from "./types";
 
 interface AppMenuProps {
   appName: string;
   appDescription: string;
   appOptions: IAppOption[];
-  appRoute: string;
+  appRoute: IAppMenuProps[];
 }
 
 function AppMenu(props: AppMenuProps) {
@@ -16,7 +16,7 @@ function AppMenu(props: AppMenuProps) {
 
   return (
     <StyledAppMenu>
-      <Breadcrumbs route={appRoute} />
+      <Breadcrumbs crumbs={appRoute} />
       <StyledTitle>
         <PageTitle
           title={appName}
@@ -25,15 +25,17 @@ function AppMenu(props: AppMenuProps) {
         />
       </StyledTitle>
       <StyledCards>
-        {appOptions.map((item) => (
-          <AppMenuCard
-            key={item.id}
-            icon={item.icon}
-            label={item.label}
-            description={item.description}
-            url={item.url}
-          />
-        ))}
+        <Grid templateColumns="" gap="s300">
+          {appOptions.map((item) => (
+            <AppMenuCard
+              key={item.id}
+              icon={item.icon}
+              label={item.label}
+              description={item.description}
+              url={item.url}
+            />
+          ))}
+        </Grid>
       </StyledCards>
     </StyledAppMenu>
   );

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -29,7 +29,7 @@ function AppMenu(props: AppMenuProps) {
 
       <Grid
         templateColumns={
-          screenMovil ? "1fr" : "repeat(auto-fill,minmax(auto, 200px))"
+          screenMovil ? "1fr" : "repeat(auto-fill,minmax(auto, 159px))"
         }
         autoRows="auto"
         gap="s300"

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -1,7 +1,7 @@
 import { AppMenuCard } from "@components/cards/AppMenuCard/index";
-import { Breadcrumbs, Grid } from "@inube/design-system";
+import { Breadcrumbs, Grid, useMediaQuery } from "@inube/design-system";
 import { PageTitle } from "../../PageTitle";
-import { StyledAppMenu, StyledCards, StyledTitle } from "./styles";
+import { StyledAppMenu, StyledTitle } from "./styles";
 import { IAppOption, IRoute } from "./types";
 
 interface AppMenuProps {
@@ -14,6 +14,8 @@ interface AppMenuProps {
 function AppMenu(props: AppMenuProps) {
   const { appName, appDescription, appOptions, appRoute } = props;
 
+  const screenMovil = useMediaQuery("(max-width: 490px)");
+  console.log(screenMovil);
   return (
     <StyledAppMenu>
       <Breadcrumbs crumbs={appRoute} />
@@ -24,23 +26,24 @@ function AppMenu(props: AppMenuProps) {
           navigatePage="/"
         />
       </StyledTitle>
-      <StyledCards>
-        <Grid
-          templetaColumn="repeat(auto, minmax(100px, 1fr));"
-          autoRows="row"
-          gap="s300"
-        >
-          {appOptions.map((item) => (
-            <AppMenuCard
-              key={item.id}
-              icon={item.icon}
-              label={item.label}
-              description={item.description}
-              url={item.url}
-            />
-          ))}
-        </Grid>
-      </StyledCards>
+
+      <Grid
+        templateColumns={
+          screenMovil ? "1fr" : "repeat(auto-fill, minmax(max-content, 160px))"
+        }
+        autoRows="row"
+        gap="s300"
+      >
+        {appOptions.map((item) => (
+          <AppMenuCard
+            key={item.id}
+            icon={item.icon}
+            label={item.label}
+            description={item.description}
+            url={item.url}
+          />
+        ))}
+      </Grid>
     </StyledAppMenu>
   );
 }

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -29,9 +29,9 @@ function AppMenu(props: AppMenuProps) {
 
       <Grid
         templateColumns={
-          screenMovil ? "1fr" : "repeat(auto-fill, minmax(max-content, 160px))"
+          screenMovil ? "1fr" : "repeat(auto-fill,minmax(auto, 200px))"
         }
-        autoRows="row"
+        autoRows="auto"
         gap="s300"
       >
         {appOptions.map((item) => (

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -13,6 +13,7 @@ interface AppMenuProps {
 
 function AppMenu(props: AppMenuProps) {
   const { appName, appDescription, appOptions, appRoute } = props;
+
   return (
     <StyledAppMenu>
       <Breadcrumbs crumbs={appRoute} />
@@ -24,7 +25,11 @@ function AppMenu(props: AppMenuProps) {
         />
       </StyledTitle>
       <StyledCards>
-        <Grid templateColumns="" gap="s300">
+        <Grid
+          templetaColumn="repeat(auto, minmax(100px, 1fr));"
+          autoRows="row"
+          gap="s300"
+        >
           {appOptions.map((item) => (
             <AppMenuCard
               key={item.id}

--- a/src/components/layout/AppMenu/index.tsx
+++ b/src/components/layout/AppMenu/index.tsx
@@ -14,8 +14,8 @@ interface AppMenuProps {
 function AppMenu(props: AppMenuProps) {
   const { appName, appDescription, appOptions, appRoute } = props;
 
-  const screenMovil = useMediaQuery("(max-width: 490px)");
-  console.log(screenMovil);
+  const screenMovil = useMediaQuery("(max-width: 360px)");
+
   return (
     <StyledAppMenu>
       <Breadcrumbs crumbs={appRoute} />

--- a/src/components/layout/AppMenu/styles.ts
+++ b/src/components/layout/AppMenu/styles.ts
@@ -4,6 +4,7 @@ const StyledAppMenu = styled.div`
   box-sizing: border-box;
   width: 100%;
   padding: 32px 64px;
+
   @media (max-width: 490px) {
     padding: 16px;
   }

--- a/src/components/layout/AppMenu/styles.ts
+++ b/src/components/layout/AppMenu/styles.ts
@@ -17,10 +17,8 @@ const StyledCards = styled.ul`
   max-width: 1400px;
   list-style: none;
   margin: 48px auto;
-  display: grid;
+
   grid-template-columns: repeat(6, auto);
-  gap: 24px;
-  padding: 0;
 
   @media screen and (max-width: 1580px) {
     grid-template-columns: repeat(5, auto);

--- a/src/components/layout/AppMenu/styles.ts
+++ b/src/components/layout/AppMenu/styles.ts
@@ -13,40 +13,4 @@ const StyledTitle = styled.div`
   margin: 32px 0;
 `;
 
-const StyledCards = styled.ul`
-  max-width: 1400px;
-  list-style: none;
-  margin: 48px auto;
-
-  grid-template-columns: repeat(6, auto);
-
-  @media screen and (max-width: 1580px) {
-    grid-template-columns: repeat(5, auto);
-  }
-
-  @media screen and (max-width: 1375px) {
-    grid-template-columns: repeat(4, auto);
-  }
-
-  @media screen and (max-width: 1170px) {
-    grid-template-columns: repeat(3, auto);
-  }
-
-  @media screen and (max-width: 960px) {
-    grid-template-columns: repeat(2, auto);
-  }
-
-  @media screen and (max-width: 850px) {
-    grid-template-columns: repeat(3, auto);
-  }
-
-  @media screen and (max-width: 710px) {
-    grid-template-columns: repeat(2, auto);
-  }
-
-  @media screen and (max-width: 490px) {
-    grid-template-columns: repeat(1, 100%);
-  }
-`;
-
-export { StyledAppMenu, StyledCards, StyledTitle };
+export { StyledAppMenu, StyledTitle };

--- a/src/components/layout/AppMenu/types.ts
+++ b/src/components/layout/AppMenu/types.ts
@@ -6,4 +6,12 @@ interface IAppOption {
   url: string;
 }
 
-export type { IAppOption };
+interface IAppMenuProps {
+  id: string;
+  label: string;
+  path: string;
+  isActive?: boolean;
+  size?: "small" | "large";
+}
+
+export type { IAppOption, IAppMenuProps };

--- a/src/pages/privileges/outlets/options/interface.tsx
+++ b/src/pages/privileges/outlets/options/interface.tsx
@@ -1,11 +1,11 @@
 import { AppMenu } from "@components/layout/AppMenu";
-import { IAppOption } from "@src/components/layout/AppMenu/types";
+import { IAppOption, IAppMenuProps } from "@components/layout/AppMenu/types";
 
 interface PrivilegesOptionsUIProps {
   appName: string;
   appDescription: string;
   appOptions: IAppOption[];
-  appRoute: string;
+  appRoute: IAppMenuProps[];
 }
 
 function PrivilegesOptionsUI(props: PrivilegesOptionsUIProps) {


### PR DESCRIPTION
When the “options” route is uncommented in routes/privileges.tsx, such route redirects to <PrivilegesOptions />.

There you will find an interface, and such interface makes use of a component called <AppMenu />.

Check that component to see that the imported Breadcrumbs are correct. Also refactor StyledCards and import <Grid >.