### PR TITLE
`Fix`: ensure the proper icon-color's use along `<AppMenu/>`,`<AppMenuCard />`, `<PageTitle />`

### DIFF
--- a/src/components/PageTitle/index.tsx
+++ b/src/components/PageTitle/index.tsx
@@ -21,7 +21,7 @@ function PageTitle(props: PageTitleProps) {
         <Stack gap="8px" alignItems="center">
           {icon ? (
             <Icon
-              appearance="primary"
+              appearance="dark"
               cursorHover={true}
               icon={icon}
               spacing="wide"
@@ -29,7 +29,7 @@ function PageTitle(props: PageTitleProps) {
             />
           ) : (
             <Icon
-              appearance="primary"
+              appearance="dark"
               cursorHover={true}
               icon={<MdArrowBack />}
               spacing="wide"

--- a/src/components/cards/AppCard/index.tsx
+++ b/src/components/cards/AppCard/index.tsx
@@ -1,6 +1,7 @@
-import { Stack, Text } from "@inube/design-system";
+import { Stack, Text, Icon } from "@inube/design-system";
 
-import { StyledAppCard, StyledIcon } from "./styles";
+import { StyledAppCard } from "./styles";
+import { useState } from "react";
 
 interface AppCardProps {
   label: string;
@@ -11,15 +12,29 @@ interface AppCardProps {
 
 function AppCard(props: AppCardProps) {
   const { label, description, icon, url } = props;
+  const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <StyledAppCard to={url}>
+    <StyledAppCard
+      to={url}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <Stack gap="16px" direction="column">
-        <Text typo="titleMedium">{label}</Text>
-        <Text typo="bodySmall">{description}</Text>
+        <Text type="title" size="medium">
+          {label}
+        </Text>
+        <Text size="small">{description}</Text>
       </Stack>
       <Stack alignItems="flex-end" direction="column">
-        <StyledIcon>{icon}</StyledIcon>
+        <Icon
+          appearance={isHovered ? "primary" : "dark"}
+          parentHover={isHovered ? true : false}
+          icon={icon}
+          spacing="wide"
+          size="24px"
+          shape="circle"
+        />
       </Stack>
     </StyledAppCard>
   );

--- a/src/components/cards/AppCard/styles.ts
+++ b/src/components/cards/AppCard/styles.ts
@@ -3,6 +3,11 @@ import styled from "styled-components";
 import { colors } from "@styles/colors";
 
 import { Link } from "react-router-dom";
+import { inube } from "@inube/design-system";
+
+interface IStyledAppCardProps {
+  theme?: typeof inube;
+}
 
 const StyledAppCard = styled(Link)`
   box-sizing: border-box;
@@ -14,14 +19,22 @@ const StyledAppCard = styled(Link)`
   justify-content: space-between;
   border-radius: 4px;
   text-decoration: none;
-  color: ${colors.ref.palette.neutral.n900};
-  border: 1px solid ${colors.ref.palette.neutral.n30};
-  box-shadow: 3px 3px 5px 1px ${colors.ref.palette.neutral.n30};
+  color: ${({ theme }: IStyledAppCardProps) =>
+    theme?.color?.stroke?.dark?.regular || inube.color.stroke.dark.regular};
+  border: 1px solid
+    ${({ theme }: IStyledAppCardProps) =>
+      theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular};
+  box-shadow: 3px 3px 5px 1px
+    ${({ theme }: IStyledAppCardProps) =>
+      theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular};
   cursor: pointer;
 
   &:hover {
-    color: ${colors.sys.actions.primary.filled};
-    background-color: ${colors.sys.actions.secondary.filled};
+    color: ${({ theme }: IStyledAppCardProps) =>
+      theme?.color?.surface?.primary?.regular ||
+      inube.color.surface.primary.regular};
+    background-color: ${({ theme }: IStyledAppCardProps) =>
+      theme?.color?.surface?.gray?.regular || inube.color.surface.gray.regular};
     box-shadow: none;
   }
 
@@ -37,11 +50,4 @@ const StyledAppCard = styled(Link)`
   }
 `;
 
-const StyledIcon = styled.i`
-  svg {
-    width: 24px;
-    height: 24px;
-  }
-`;
-
-export { StyledAppCard, StyledIcon };
+export { StyledAppCard };


### PR DESCRIPTION
This PR addresses inconsistencies in the usage of icon-color across the `<AppMenu/>`, `<AppMenuCard />`, and `<PageTitle />` components. The goal is to ensure uniformity, adherence to our design guidelines, and overall visual coherence when it comes to icon coloring within these components.