### PR TITLE
Use new Text component of inube in `<RadioClient />`

### DIFF
--- a/src/components/cards/RadioClient/index.tsx
+++ b/src/components/cards/RadioClient/index.tsx
@@ -22,7 +22,7 @@ function RadioClient(props: RadioClientProps) {
         value={value}
         onChange={handleChange}
       />
-      <Text typo="bodyMedium">{label}</Text>
+      <Text size="medium">{label}</Text>
       <StyledImage src={logo} alt="Logo de empresa" />
     </StyledRadioClient>
   );


### PR DESCRIPTION
The use of the `<Text />` component of the inube design system is implemented, which allows standardization in terms of the layout and presentation of the component