### PR TITLE
Refactor to use `<Stack />`, `<Button/>` and `<Text />` components in `<ItemNotFound/>`

### DIFF
--- a/src/components/layout/ItemNotFound/index.tsx
+++ b/src/components/layout/ItemNotFound/index.tsx
@@ -1,5 +1,4 @@
-import { StyledInfo } from "./styles";
-import { Stack, Text, Button, useMediaQuery } from "@inube/design-system";
+import { Button, Stack, Text, useMediaQuery } from "@inube/design-system";
 
 interface ItemNotFoundProps {
   image: string;
@@ -11,30 +10,35 @@ interface ItemNotFoundProps {
 
 function ItemNotFound(props: ItemNotFoundProps) {
   const { image, title, description, buttonDescription, route } = props;
-  const smallScreen = useMediaQuery("(max-width: 580px)");
+  const smallScreen = useMediaQuery("(max-width: 312px)");
 
   return (
     <Stack
       direction="column"
       gap={smallScreen ? "24px" : "32px"}
       alignItems="center"
-      margin="40px"
+      margin="s400"
     >
       <img src={image} alt="ItemNotFoundAlt" />
-      <StyledInfo>
-        <Stack direction="column" gap={smallScreen ? "8px" : "24px"}>
-          <Text typo={smallScreen ? "titleSmall" : "titleLarge"} align="center">
-            {title}
-          </Text>
-          <Text
-            typo={smallScreen ? "bodySmall" : "titleMedium"}
-            align="center"
-            appearance="secondary"
-          >
-            {description}
-          </Text>
-        </Stack>
-      </StyledInfo>
+
+      <Stack direction="column" gap={smallScreen ? "8px" : "24px"}>
+        <Text
+          type="title"
+          size={smallScreen ? "small" : "large"}
+          textAlign="center"
+        >
+          {title}
+        </Text>
+        <Text
+          type={smallScreen ? "body" : "title"}
+          size={smallScreen ? "small" : "medium"}
+          textAlign="center"
+          appearance="gray"
+        >
+          {description}
+        </Text>
+      </Stack>
+
       <Button type="link" variant="none" spacing="compact" path={route}>
         {buttonDescription}
       </Button>

--- a/src/components/layout/ItemNotFound/styles.ts
+++ b/src/components/layout/ItemNotFound/styles.ts
@@ -1,7 +1,0 @@
-import styled from "styled-components";
-
-const StyledInfo = styled.div`
-  max-width: 500px;
-`;
-
-export { StyledInfo };


### PR DESCRIPTION
The component is refactored and the `styled components` are **replaced** by components of the **inube design system**, which allows the standardization of styles and other presentation elements. 