### PR TITLE
`Reorganize:` Move `Menu.stories.tsx` to `Menu` Directory

### DIFF
--- a/src/components/navigation/Menu/Menu.stories.tsx
+++ b/src/components/navigation/Menu/Menu.stories.tsx
@@ -1,8 +1,8 @@
 import { menuInvitationLinks } from "@pages/privileges/outlets/users/config/menuInvitation.config";
 import { action } from "@storybook/addon-actions";
 import { BrowserRouter } from "react-router-dom";
-import { Menu, MenuProps } from "..";
-import { IOption } from "../types";
+import { Menu, MenuProps } from ".";
+import { IOption } from "./types";
 import { StoryFn } from "@storybook/react";
 
 const story = {

--- a/src/components/navigation/MenuLink/MenuLink.stories.tsx
+++ b/src/components/navigation/MenuLink/MenuLink.stories.tsx
@@ -1,6 +1,6 @@
 import { menuInvitationLinks } from "@pages/privileges/outlets/users/config/menuInvitation.config";
 import { BrowserRouter } from "react-router-dom";
-import { MenuLink, MenuLinkprops } from "..";
+import { MenuLink, MenuLinkprops } from ".";
 import { StoryFn } from "@storybook/react";
 
 const story = {


### PR DESCRIPTION
This PR enhances the organization of our component structure by relocating the `Menu.stories.tsx` file from the stories directory to the main `Menu` directory. This change is part of our continuous efforts to streamline the file structure, making it more intuitive and maintainable.