### PR TITLE
`Refactor:` Implement `<Grid/>` in Home Component and Remove `StyledAppsList` and implement new tokens

### DIFF
--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -5,11 +5,7 @@ import { Header, Grid, Stack, useMediaQueries } from "@inube/design-system";
 import { AppContext } from "@src/context";
 import { PageTitle } from "@components/PageTitle";
 import { AppCard } from "@components/cards/AppCard";
-import {
-  mediaQuerySettings,
-  appListpaddingSettings,
-  pageTitlePaddingSettings,
-} from "./types";
+import { mediaQuerySettings, pageTitlePaddingSettings } from "./types";
 import {
   StyledContentImg,
   StyledLogo,
@@ -18,18 +14,6 @@ import {
 import { IApps } from "./types";
 import { navigationConfig } from "./config/apps.config";
 import { StyledHome } from "./styles";
-
-const getSettingsAccordingMediaQuery = (
-  mediaQueries: string[],
-  matches: { [x: string]: boolean },
-  mediaQuerieParameters: { [x: string]: string },
-  defaultValue: string
-): string => {
-  const matchingQuery = mediaQueries.find(
-    (mediaQuerie) => matches[mediaQuerie]
-  );
-  return matchingQuery ? mediaQuerieParameters[matchingQuery] : defaultValue;
-};
 
 const getPageTitlePadding = (
   matches: { [x: string]: boolean },
@@ -71,8 +55,8 @@ function HomeUI(props: HomeUIProps) {
         client={user.company}
       />
       <Stack
-        id="PageTitle"
-        gap="4px"
+        gap="20px"
+        direction="column"
         padding={getPageTitlePadding(matches, pageTitlePaddingSettings)}
       >
         <PageTitle
@@ -80,39 +64,28 @@ function HomeUI(props: HomeUIProps) {
           description="Selecciona una opción para empezar a ajustar la configuración de tu software Linix"
           icon={<MdOutlineDoorFront />}
         />
+        <Grid
+          templateColumns="repeat( auto-fit, minmax(250px, 1fr) )"
+          justifyContent="center"
+          alignItems="start"
+          alignContent="start"
+          gap="s300"
+          padding="s0"
+          margin="s0 auto"
+        >
+          {apps.map((app) => (
+            <li key={app.url}>
+              <AppCard
+                key={app.id}
+                label={app.label}
+                description={app.description}
+                icon={app.icon}
+                url={app.url}
+              />
+            </li>
+          ))}
+        </Grid>
       </Stack>
-
-      <Grid
-        templateColumns={getSettingsAccordingMediaQuery(
-          mediaQueries,
-          matches,
-          mediaQuerySettings,
-          "repeat(6, 16%)"
-        )}
-        justifyContent={"center"}
-        alignItems="start"
-        alignContent="start"
-        gap="s300"
-        padding={getSettingsAccordingMediaQuery(
-          mediaQueries,
-          matches,
-          appListpaddingSettings,
-          "s0 s800"
-        )}
-        margin="s0 auto"
-      >
-        {apps.map((app) => (
-          <li key={app.url}>
-            <AppCard
-              key={app.id}
-              label={app.label}
-              description={app.description}
-              icon={app.icon}
-              url={app.url}
-            />
-          </li>
-        ))}
-      </Grid>
     </StyledHome>
   );
 }

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -20,8 +20,8 @@ import { navigationConfig } from "./config/apps.config";
 import { StyledAppsList, StyledHome } from "./styles";
 
 const getTemplateColumns = (
-  mediaQueries: any[],
-  matches: { [x: string]: unknown },
+  mediaQueries: string[],
+  matches: { [x: string]: boolean },
   templateColumnsSettings: { [x: string]: string }
 ): string => {
   const matchingQuery = mediaQueries.find(
@@ -33,8 +33,8 @@ const getTemplateColumns = (
 };
 
 const getPadding = (
-  mediaQueries: any[],
-  matches: { [x: string]: unknown },
+  mediaQueries: string[],
+  matches: { [x: string]: boolean },
   appListpaddingSettings: { [x: string]: string }
 ): string => {
   const matchingQuery = mediaQueries.find(
@@ -44,7 +44,7 @@ const getPadding = (
 };
 
 const getPageTitlePadding = (
-  matches: { [x: string]: unknown },
+  matches: { [x: string]: boolean },
   pageTitlePaddingSettings: { [x: string]: string }
 ) => {
   const matchingQuery = Object.keys(pageTitlePaddingSettings).find(
@@ -69,9 +69,7 @@ function HomeUI(props: HomeUIProps) {
   const { apps } = props;
   const { user } = useContext(AppContext);
 
-  const mediaQueries = Object.keys(
-    mediaQuerySettings
-  ) as (keyof typeof mediaQuerySettings)[];
+  const mediaQueries = Object.keys(mediaQuerySettings);
 
   const matches = useMediaQueries(mediaQueries);
 

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -25,28 +25,16 @@ import { IApps } from "./types";
 import { navigationConfig } from "./config/apps.config";
 import { StyledHome } from "./styles";
 
-const getTemplateColumns = (
+const getSettingsAccordingMediaQuery = (
   mediaQueries: string[],
   matches: { [x: string]: boolean },
-  templateColumnsSettings: { [x: string]: string }
+  mediaQuerieParameters: { [x: string]: string },
+  defaultValue: string
 ): string => {
   const matchingQuery = mediaQueries.find(
     (mediaQuerie) => matches[mediaQuerie]
   );
-  return matchingQuery
-    ? templateColumnsSettings[matchingQuery]
-    : "repeat(auto-fit, 250px)";
-};
-
-const getPadding = (
-  mediaQueries: string[],
-  matches: { [x: string]: boolean },
-  appListpaddingSettings: { [x: string]: string }
-): string => {
-  const matchingQuery = mediaQueries.find(
-    (mediaQuerie) => matches[mediaQuerie]
-  );
-  return matchingQuery ? appListpaddingSettings[matchingQuery] : "s0 s800";
+  return matchingQuery ? mediaQuerieParameters[matchingQuery] : defaultValue;
 };
 
 const getPageTitlePadding = (
@@ -101,18 +89,22 @@ function HomeUI(props: HomeUIProps) {
       </Stack>
 
       <Grid
-        templateColumns={getTemplateColumns(
+        templateColumns={getSettingsAccordingMediaQuery(
           mediaQueries,
           matches,
-          mediaQuerySettings
+          mediaQuerySettings,
+          "repeat(6, 16%)"
         )}
-        justifyContent={
-          useMediaQuery("(max-width: 1480px)") ? "center" : "start"
-        }
-        alignItems="center"
+        justifyContent={"center"}
+        alignItems="start"
         alignContent="start"
         gap="s300"
-        padding={getPadding(mediaQueries, matches, appListpaddingSettings)}
+        padding={getSettingsAccordingMediaQuery(
+          mediaQueries,
+          matches,
+          appListpaddingSettings,
+          "s0 s800"
+        )}
         margin="s0 auto"
       >
         {apps.map((app) => (

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -17,7 +17,7 @@ import {
 
 import { IApps } from "./types";
 import { navigationConfig } from "./config/apps.config";
-import { StyledAppsList, StyledHome } from "./styles";
+import { StyledHome } from "./styles";
 
 const getTemplateColumns = (
   mediaQueries: string[],
@@ -29,7 +29,7 @@ const getTemplateColumns = (
   );
   return matchingQuery
     ? templateColumnsSettings[matchingQuery]
-    : "repeat(5, 250px)";
+    : "repeat(auto-fit, 250px)";
 };
 
 const getPadding = (
@@ -93,31 +93,32 @@ function HomeUI(props: HomeUIProps) {
           icon={<MdOutlineDoorFront />}
         />
       </Stack>
-      <StyledAppsList>
-        <Grid
-          templateColumns={getTemplateColumns(
-            mediaQueries,
-            matches,
-            mediaQuerySettings
-          )}
-          justifyContent="center"
-          gap="s300"
-          padding={getPadding(mediaQueries, matches, appListpaddingSettings)}
-          margin="s0 auto"
-        >
-          {apps.map((app) => (
-            <li key={app.url}>
-              <AppCard
-                key={app.id}
-                label={app.label}
-                description={app.description}
-                icon={app.icon}
-                url={app.url}
-              />
-            </li>
-          ))}
-        </Grid>
-      </StyledAppsList>
+
+      <Grid
+        templateColumns={getTemplateColumns(
+          mediaQueries,
+          matches,
+          mediaQuerySettings
+        )}
+        justifyContent="center"
+        alignItems="center"
+        alignContent="start"
+        gap="s300"
+        padding={getPadding(mediaQueries, matches, appListpaddingSettings)}
+        margin="s0 auto"
+      >
+        {apps.map((app) => (
+          <li key={app.url}>
+            <AppCard
+              key={app.id}
+              label={app.label}
+              description={app.description}
+              icon={app.icon}
+              url={app.url}
+            />
+          </li>
+        ))}
+      </Grid>
     </StyledHome>
   );
 }

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -1,6 +1,12 @@
 import { useContext } from "react";
 import { MdOutlineDoorFront } from "react-icons/md";
-import { Header, Grid, Stack, useMediaQueries } from "@inube/design-system";
+import {
+  Header,
+  Grid,
+  Stack,
+  useMediaQueries,
+  useMediaQuery,
+} from "@inube/design-system";
 
 import { AppContext } from "@src/context";
 import { PageTitle } from "@components/PageTitle";
@@ -100,7 +106,9 @@ function HomeUI(props: HomeUIProps) {
           matches,
           mediaQuerySettings
         )}
-        justifyContent="center"
+        justifyContent={
+          useMediaQuery("(max-width: 1480px)") ? "center" : "start"
+        }
         alignItems="center"
         alignContent="start"
         gap="s300"

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -41,7 +41,7 @@ function HomeUI(props: HomeUIProps) {
   const { apps } = props;
   const { user } = useContext(AppContext);
 
-  const mediaQueries = Object.keys(mediaQuerySettings);
+  const mediaQueries = mediaQuerySettings;
 
   const matches = useMediaQueries(mediaQueries);
 

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -1,11 +1,15 @@
 import { useContext } from "react";
 import { MdOutlineDoorFront } from "react-icons/md";
-import { Header } from "@inube/design-system";
+import { Header, Grid, Stack, useMediaQueries } from "@inube/design-system";
 
 import { AppContext } from "@src/context";
 import { PageTitle } from "@components/PageTitle";
 import { AppCard } from "@components/cards/AppCard";
-
+import {
+  mediaQuerySettings,
+  appListpaddingSettings,
+  pageTitlePaddingSettings,
+} from "./types";
 import {
   StyledContentImg,
   StyledLogo,
@@ -13,7 +17,41 @@ import {
 
 import { IApps } from "./types";
 import { navigationConfig } from "./config/apps.config";
-import { StyledAppsList, StyledHome, StyledPageTitle } from "./styles";
+import { StyledAppsList, StyledHome } from "./styles";
+
+const getTemplateColumns = (
+  mediaQueries: any[],
+  matches: { [x: string]: unknown },
+  templateColumnsSettings: { [x: string]: string }
+): string => {
+  const matchingQuery = mediaQueries.find(
+    (mediaQuerie) => matches[mediaQuerie]
+  );
+  return matchingQuery
+    ? templateColumnsSettings[matchingQuery]
+    : "repeat(5, 250px)";
+};
+
+const getPadding = (
+  mediaQueries: any[],
+  matches: { [x: string]: unknown },
+  appListpaddingSettings: { [x: string]: string }
+): string => {
+  const matchingQuery = mediaQueries.find(
+    (mediaQuerie) => matches[mediaQuerie]
+  );
+  return matchingQuery ? appListpaddingSettings[matchingQuery] : "s0 s800";
+};
+
+const getPageTitlePadding = (
+  matches: { [x: string]: unknown },
+  pageTitlePaddingSettings: { [x: string]: string }
+) => {
+  const matchingQuery = Object.keys(pageTitlePaddingSettings).find(
+    (mediaQuerie) => matches[mediaQuerie]
+  );
+  return matchingQuery ? pageTitlePaddingSettings[matchingQuery] : "s400 s800";
+};
 
 const renderLogo = (imgUrl: string) => {
   return (
@@ -31,6 +69,12 @@ function HomeUI(props: HomeUIProps) {
   const { apps } = props;
   const { user } = useContext(AppContext);
 
+  const mediaQueries = Object.keys(
+    mediaQuerySettings
+  ) as (keyof typeof mediaQuerySettings)[];
+
+  const matches = useMediaQueries(mediaQueries);
+
   return (
     <StyledHome>
       <Header
@@ -40,25 +84,41 @@ function HomeUI(props: HomeUIProps) {
         userName={user.username}
         client={user.company}
       />
-      <StyledPageTitle>
+      <Stack
+        id="PageTitle"
+        gap="4px"
+        padding={getPageTitlePadding(matches, pageTitlePaddingSettings)}
+      >
         <PageTitle
           title={`Bienvenido ${user.username}`}
           description="Selecciona una opción para empezar a ajustar la configuración de tu software Linix"
           icon={<MdOutlineDoorFront />}
         />
-      </StyledPageTitle>
+      </Stack>
       <StyledAppsList>
-        {apps.map((app) => (
-          <li key={app.url}>
-            <AppCard
-              key={app.id}
-              label={app.label}
-              description={app.description}
-              icon={app.icon}
-              url={app.url}
-            />
-          </li>
-        ))}
+        <Grid
+          templateColumns={getTemplateColumns(
+            mediaQueries,
+            matches,
+            mediaQuerySettings
+          )}
+          justifyContent="center"
+          gap="s300"
+          padding={getPadding(mediaQueries, matches, appListpaddingSettings)}
+          margin="s0 auto"
+        >
+          {apps.map((app) => (
+            <li key={app.url}>
+              <AppCard
+                key={app.id}
+                label={app.label}
+                description={app.description}
+                icon={app.icon}
+                url={app.url}
+              />
+            </li>
+          ))}
+        </Grid>
       </StyledAppsList>
     </StyledHome>
   );

--- a/src/pages/home/interface.tsx
+++ b/src/pages/home/interface.tsx
@@ -1,12 +1,6 @@
 import { useContext } from "react";
 import { MdOutlineDoorFront } from "react-icons/md";
-import {
-  Header,
-  Grid,
-  Stack,
-  useMediaQueries,
-  useMediaQuery,
-} from "@inube/design-system";
+import { Header, Grid, Stack, useMediaQueries } from "@inube/design-system";
 
 import { AppContext } from "@src/context";
 import { PageTitle } from "@components/PageTitle";

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -8,13 +8,9 @@ const StyledHome = styled.div`
   #PageTitle {
     max-width: 1400px;
   }
+  li {
+    list-style: none;
+  }
 `;
 
-const StyledAppsList = styled.ul`
-  box-sizing: border-box;
-  max-width: 1400px;
-  list-style: none;
-  margin: 0 auto;
-`;
-
-export { StyledHome, StyledAppsList };
+export { StyledHome };

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -5,22 +5,8 @@ const StyledHome = styled.div`
   padding-bottom: 40px;
   height: 100vh;
   overflow-y: scroll;
-`;
-
-const StyledPageTitle = styled.div`
-  max-width: 1400px;
-  padding: 32px 64px;
-
-  @media screen and (max-width: 660px) {
-    padding: 24px 32px 32px;
-  }
-
-  @media screen and (max-width: 590px) {
-    padding: 24px 16px 32px;
-
-    div {
-      gap: 4px;
-    }
+  #PageTitle {
+    max-width: 1400px;
   }
 `;
 
@@ -29,32 +15,6 @@ const StyledAppsList = styled.ul`
   max-width: 1400px;
   list-style: none;
   margin: 0 auto;
-  padding: 0px 64px;
-  display: grid;
-  grid-template-columns: repeat(5, 250px);
-  justify-content: center;
-  gap: 24px;
-
-  @media screen and (max-width: 1480px) {
-    grid-template-columns: repeat(4, 250px);
-  }
-
-  @media screen and (max-width: 1210px) {
-    grid-template-columns: repeat(3, 250px);
-  }
-
-  @media screen and (max-width: 930px) {
-    grid-template-columns: repeat(2, 250px);
-  }
-
-  @media screen and (max-width: 660px) {
-    padding: 0px 32px;
-  }
-
-  @media screen and (max-width: 590px) {
-    grid-template-columns: repeat(1, 100%);
-    padding: 0px 16px;
-  }
 `;
 
-export { StyledHome, StyledAppsList, StyledPageTitle };
+export { StyledHome, StyledAppsList };

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -8,9 +8,11 @@ interface IApps {
 
 const mediaQuerySettings = {
   "(max-width: 660px)": "100%",
-  "(max-width: 930px)": "repeat(2, 250px)",
-  "(max-width: 1210px)": "repeat(3, 250px)",
-  "(max-width: 1480px)": "repeat(4, 250px)",
+  "(max-width: 806px)": "repeat(2, 40%)",
+  "(max-width: 930px)": "repeat(2, 42%)",
+  "(max-width: 1210px)": "repeat(3, 28%)",
+  "(max-width: 1480px)": "repeat(4, 21%)",
+  "(min-width: 1481px)": "repeat(5, 18%)",
 };
 
 const appListpaddingSettings = {

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -6,7 +6,7 @@ interface IApps {
   url: string;
 }
 
-const mediaQuerySettings: Record<string, string> = {
+const mediaQuerySettings = {
   "(max-width: 590px)": "repeat(1, 100%)",
   "(max-width: 660px)": "repeat(1, 100%)",
   "(max-width: 930px)": "repeat(2, 250px)",
@@ -14,7 +14,7 @@ const mediaQuerySettings: Record<string, string> = {
   "(max-width: 1480px)": "repeat(4, 250px)",
 };
 
-const appListpaddingSettings: Record<string, string> = {
+const appListpaddingSettings = {
   "(max-width: 590px)": "s0 s200",
   "(max-width: 660px)": "s0 s400",
 };

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -6,14 +6,14 @@ interface IApps {
   url: string;
 }
 
-const mediaQuerySettings = {
-  "(max-width: 660px)": "100%",
-  "(max-width: 806px)": "repeat(2, 40%)",
-  "(max-width: 930px)": "repeat(2, 42%)",
-  "(max-width: 1210px)": "repeat(3, 28%)",
-  "(max-width: 1480px)": "repeat(4, 21%)",
-  "(min-width: 1481px)": "repeat(5, 18%)",
-};
+const mediaQuerySettings = [
+  "(max-width: 660px)",
+  "(max-width: 806px)",
+  "(max-width: 930px)",
+  "(max-width: 1210px)",
+  "(max-width: 1480px)",
+  "(min-width: 1481px)",
+];
 
 const appListpaddingSettings = {
   "(max-width: 590px)": "s0 s200",

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -6,4 +6,22 @@ interface IApps {
   url: string;
 }
 
+const mediaQuerySettings: Record<string, string> = {
+  "(max-width: 590px)": "repeat(1, 100%)",
+  "(max-width: 660px)": "repeat(1, 100%)",
+  "(max-width: 930px)": "repeat(2, 250px)",
+  "(max-width: 1210px)": "repeat(3, 250px)",
+  "(max-width: 1480px)": "repeat(4, 250px)",
+};
+
+const appListpaddingSettings: Record<string, string> = {
+  "(max-width: 590px)": "s0 s200",
+  "(max-width: 660px)": "s0 s400",
+};
+
+const pageTitlePaddingSettings = {
+  "(max-width: 590px)": "s300 s200 s400",
+  "(max-width: 660px)": "s300 s400 s400",
+};
+export { mediaQuerySettings, appListpaddingSettings, pageTitlePaddingSettings };
 export type { IApps };

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -7,8 +7,7 @@ interface IApps {
 }
 
 const mediaQuerySettings = {
-  "(max-width: 590px)": "repeat(1, 100%)",
-  "(max-width: 660px)": "repeat(1, 100%)",
+  "(max-width: 660px)": "100%",
   "(max-width: 930px)": "repeat(2, 250px)",
   "(max-width: 1210px)": "repeat(3, 250px)",
   "(max-width: 1480px)": "repeat(4, 250px)",
@@ -23,5 +22,6 @@ const pageTitlePaddingSettings = {
   "(max-width: 590px)": "s300 s200 s400",
   "(max-width: 660px)": "s300 s400 s400",
 };
+
 export { mediaQuerySettings, appListpaddingSettings, pageTitlePaddingSettings };
 export type { IApps };


### PR DESCRIPTION
In this PR, we're refocusing our Home component to utilize the `<Grid/>` component from our design system, replacing the current `StyledAppsList`. This move aligns with our initiative to standardize our UI components across the application and improve maintainability. By doing so, we're enhancing the Home component's structure and reducing the reliance on custom-styled components.