### PR TITLE
Fix: Implement Responsive `<Tabs/>` Component with Media Queries

### DIFF
--- a/src/pages/privileges/outlets/users/edit-user/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/interface.tsx
@@ -1,7 +1,12 @@
 import { PageTitle } from "@components/PageTitle";
 import { SubjectCard } from "@components/cards/SubjectCard";
 import { ItemNotFound } from "@components/layout/ItemNotFound";
-import { Breadcrumbs, Stack, Tabs, useMediaQuery } from "@inube/design-system";
+import {
+  Breadcrumbs,
+  Stack,
+  Tabs,
+  useMediaQueries,
+} from "@inube/design-system";
 import { DecisionModal } from "@components/feedback/DecisionModal";
 import { editUserContinueModalConfig } from "./config/editUser.config";
 import {
@@ -71,7 +76,8 @@ function EditUserUI(props: EditUserUIProps) {
     handleContinueTab,
   } = props;
 
-  const smallScreen = useMediaQuery("(max-width: 580px)");
+  const { "(max-width: 580px)": smallScreen, "(max-width: 1073px)": typeTabs } =
+    useMediaQueries(["(max-width: 580px)", "(max-width: 1073px)"]);
 
   const {
     generalInformation: { entries: currentInformation },
@@ -110,6 +116,7 @@ function EditUserUI(props: EditUserUIProps) {
             <Tabs
               tabs={Object.values(editUserTabsConfig)}
               selectedTab={selectedTab}
+              type={typeTabs ? "select" : "tabs"}
               onChange={handleTabChange}
             />
             {selectedTab === editUserTabsConfig.generalInformation.id && (

--- a/src/pages/privileges/outlets/users/interface.tsx
+++ b/src/pages/privileges/outlets/users/interface.tsx
@@ -92,6 +92,7 @@ export function UsersUI(props: UsersUIProps) {
               tabs={Object.values(privilegeUserTabsConfig)}
               selectedTab={isSelected}
               onChange={handleTabChange}
+              type={smallScreen ? "select" : "tabs"}
             />
             <Stack justifyContent="space-between" alignItems="center">
               <StyledTextFieldContainer>


### PR DESCRIPTION
Modify the <Tabs/> component to ensure it is responsive and adapts its layout based on the screen size. The component should display as traditional tabs on larger screens and transform into a dropdown select menu on smaller screens.