### PR TITLE
Fix spacing between `<Breadcrumbs />` and `<PageTitle />`  in `<UserUI />`

### DIFF
--- a/src/pages/privileges/outlets/users/interface.tsx
+++ b/src/pages/privileges/outlets/users/interface.tsx
@@ -79,7 +79,7 @@ export function UsersUI(props: UsersUIProps) {
         padding={smallScreen ? "s100" : "s800"}
       >
         <Stack gap="48px" direction="column">
-          <Stack gap="32px" direction="column">
+          <Stack gap="24px" direction="column">
             <Breadcrumbs crumbs={privilegeOptionsConfig[0].crumbs} />
             <PageTitle
               title={privilegeConfig.label}


### PR DESCRIPTION
Update the spacing layout of the `<Breadcrumbs />` and `<PageTitle />` components in `<UserUI />`, adjusting them to the implemented templates. 