### PR TITLE
Fix: `Breadcrumb` Converting to Spanish

### DIFF
--- a/src/pages/home/config/apps.config.tsx
+++ b/src/pages/home/config/apps.config.tsx
@@ -10,7 +10,7 @@ const appsConfig = [
       {
         path: "/",
         label: "Inicio",
-        id: "/home",
+        id: "/",
         isActive: false,
       },
       {

--- a/src/pages/privileges/outlets/options/config/privileges.config.tsx
+++ b/src/pages/privileges/outlets/options/config/privileges.config.tsx
@@ -21,13 +21,13 @@ const privilegeOptionsConfig = [
       },
       {
         path: "/privileges",
-        label: "privileges",
+        label: "Privilegios",
         id: "/privileges",
         isActive: false,
       },
       {
         path: "/users",
-        label: "users",
+        label: "Usuarios",
         id: "/users",
         isActive: true,
       },

--- a/src/pages/privileges/outlets/users/complete-invitation/config/completeInvitation.config.tsx
+++ b/src/pages/privileges/outlets/users/complete-invitation/config/completeInvitation.config.tsx
@@ -71,7 +71,7 @@ const CompleteInvitationUserConfig = [
       },
       {
         path: "/completeUserRegistration",
-        label: "Completar Registro de Usuario",
+        label: "Completar registro de usuario",
         id: "/completeUserRegistration",
         isActive: true,
       },

--- a/src/pages/privileges/outlets/users/complete-invitation/config/completeInvitation.config.tsx
+++ b/src/pages/privileges/outlets/users/complete-invitation/config/completeInvitation.config.tsx
@@ -71,7 +71,7 @@ const CompleteInvitationUserConfig = [
       },
       {
         path: "/completeUserRegistration",
-        label: "Complete user registration",
+        label: "Completar Registro de Usuario",
         id: "/completeUserRegistration",
         isActive: true,
       },

--- a/src/pages/privileges/outlets/users/edit-user/config/editUser.config.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/config/editUser.config.tsx
@@ -27,7 +27,7 @@ const editUserOptionsConfig = {
       },
       {
         path: "/userEdition",
-        label: "user edition",
+        label: "Edicion de usuario",
         id: "/userEdition",
         isActive: true,
       },

--- a/src/pages/privileges/outlets/users/invite/config/usersInvitations.config.tsx
+++ b/src/pages/privileges/outlets/users/invite/config/usersInvitations.config.tsx
@@ -26,7 +26,7 @@ const usersInvitationsConfig = [
       },
       {
         path: "/invite",
-        label: "invite",
+        label: "Invitacion",
         id: "/invite",
         isActive: true,
       },


### PR DESCRIPTION
This PR addresses the crucial task of localizing `breadcrumb` text displays from English to Spanish. As a significant portion of our system's components are already available in Spanish, this update is essential to ensure language consistency throughout the user interface. We aim to review and modify the breadcrumb components to display text in Spanish, aligning with our localization strategy and significantly enhancing the user experience for Spanish-speaking users.