### PR TITLE
Capitalize only the first word in page title

### DIFF
--- a/src/pages/privileges/outlets/users/edit-user/config/editUser.config.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/config/editUser.config.tsx
@@ -3,7 +3,7 @@ import { EAppearance } from "@src/types/colors.types";
 const editUserOptionsConfig = {
   editUserPage: {
     id: 1,
-    label: "Editar Usuario",
+    label: "Editar usuario",
     description: "Editar las propiedades y privilegios del usuario",
     url: "/privileges/users/user edition",
     crumbs: [


### PR DESCRIPTION
Write only the first word in capital letters in the page titles, in the `ditUserOptionsConfig` service