### PR TITLE
Fix: Update Icons in `Users` and `Invitations` Tables to Use Outline Versions and Correct Color Tokens

### DIFF
--- a/src/pages/privileges/outlets/users/tabs/invitations/CompleteInvitationLink/index.tsx
+++ b/src/pages/privileges/outlets/users/tabs/invitations/CompleteInvitationLink/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { MdOutlineAssignmentTurnedIn } from "react-icons/md";
 import { Button, Icon } from "@inube/design-system";
 import { IGeneralInformationEntry } from "../../../types/forms.types";
+import { useState } from "react";
 
 interface CompleteInvitationLinkProps {
   invitation: IGeneralInformationEntry;
@@ -10,6 +11,7 @@ interface CompleteInvitationLinkProps {
 
 function CompleteInvitationLink(props: CompleteInvitationLinkProps) {
   const { invitation, showComplete } = props;
+  const [isHovered, setIsHovered] = useState(false);
 
   return (
     <>
@@ -32,9 +34,13 @@ function CompleteInvitationLink(props: CompleteInvitationLinkProps) {
               ? `complete-invitation/${invitation.id}`
               : ""
           }
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         >
           <Icon
-            appearance={"dark"}
+            appearance={isHovered ? "primary" : "dark"}
+            parentHover={isHovered ? true : false}
+            cursorHover
             icon={<MdOutlineAssignmentTurnedIn />}
             disabled={invitation.status === "Sent"}
           />

--- a/src/pages/privileges/outlets/users/tabs/invitations/DeleteInvitation/interface.tsx
+++ b/src/pages/privileges/outlets/users/tabs/invitations/DeleteInvitation/interface.tsx
@@ -2,6 +2,7 @@ import { DecisionModal } from "@components/feedback/DecisionModal";
 import { Button, Icon } from "@inube/design-system";
 import { MdOutlineDelete } from "react-icons/md";
 import { deleteInvitationModalConfig } from "../../../config/invitationsTable.config";
+import { useState } from "react";
 
 interface DeleteInvitationUIProps {
   handleRemoveInvitation: () => void;
@@ -13,6 +14,7 @@ interface DeleteInvitationUIProps {
 function DeleteInvitationUI(props: DeleteInvitationUIProps) {
   const { handleRemoveInvitation, showModal, toggleModal, showComplete } =
     props;
+  const [isHovered, setIsHovered] = useState(false);
 
   const { title, description, actionText, appearance } =
     deleteInvitationModalConfig;
@@ -30,12 +32,18 @@ function DeleteInvitationUI(props: DeleteInvitationUIProps) {
           Eliminar
         </Button>
       ) : (
-        <Icon
-          icon={<MdOutlineDelete />}
-          onClick={toggleModal}
-          appearance="primary"
-          cursorHover
-        />
+        <div
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <Icon
+            icon={<MdOutlineDelete />}
+            onClick={toggleModal}
+            appearance={isHovered ? "primary" : "dark"}
+            parentHover={isHovered ? true : false}
+            cursorHover
+          />
+        </div>
       )}
 
       {showModal && (

--- a/src/pages/privileges/outlets/users/tabs/invitations/ResendInvitation/interface.tsx
+++ b/src/pages/privileges/outlets/users/tabs/invitations/ResendInvitation/interface.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from "@inube/design-system";
 import { MdOutlineShortcut } from "react-icons/md";
 import { resendInvitationModal } from "../../../config/resendInvitationUser.config";
 import { IGeneralInformationEntry } from "../../../types/forms.types";
+import { useState } from "react";
 
 interface ResendInvitationUIProps {
   showResendInvModal: boolean;
@@ -21,6 +22,7 @@ function ResendInvitationUI(props: ResendInvitationUIProps) {
     showComplete,
   } = props;
   const { title, description, textAction, appearance } = resendInvitationModal;
+  const [isHovered, setIsHovered] = useState(false);
 
   return (
     <>
@@ -35,13 +37,19 @@ function ResendInvitationUI(props: ResendInvitationUIProps) {
           Reenviar
         </Button>
       ) : (
-        <Icon
-          appearance={"dark"}
-          icon={<MdOutlineShortcut />}
-          disabled={invitation.status === "Sent"}
-          cursorHover
-          onClick={toggleModal}
-        />
+        <div
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <Icon
+            appearance={isHovered ? "primary" : "dark"}
+            parentHover={isHovered ? true : false}
+            icon={<MdOutlineShortcut />}
+            disabled={invitation.status === "Sent"}
+            cursorHover
+            onClick={toggleModal}
+          />
+        </div>
       )}
 
       {showResendInvModal && (

--- a/src/pages/privileges/outlets/users/tabs/users/DeleteUser/interface.tsx
+++ b/src/pages/privileges/outlets/users/tabs/users/DeleteUser/interface.tsx
@@ -5,6 +5,7 @@ import { EMessageType } from "@src/types/messages.types";
 import { deleteUserModal } from "../../../config/deleteUser.config";
 import { IGeneralInformationEntry } from "../../../types/forms.types";
 import { IDeleteUserModal } from "./types";
+import { useState } from "react";
 
 interface DeleteUserUIProps {
   user: IGeneralInformationEntry;
@@ -42,6 +43,8 @@ function DeleteUserUI(props: DeleteUserUIProps) {
     closeModal,
     showComplete,
   } = props;
+  const [isHovered, setIsHovered] = useState(false);
+
   return (
     <>
       {showComplete ? (
@@ -55,12 +58,18 @@ function DeleteUserUI(props: DeleteUserUIProps) {
           Eliminar
         </Button>
       ) : (
-        <Icon
-          icon={<MdOutlineDelete />}
-          onClick={handleShowModal}
-          appearance="primary"
-          cursorHover
-        />
+        <div
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <Icon
+            icon={<MdOutlineDelete />}
+            onClick={handleShowModal}
+            appearance={isHovered ? "primary" : "dark"}
+            parentHover={isHovered ? true : false}
+            cursorHover
+          />
+        </div>
       )}
 
       {showModal && DeleteUserModal({ user, closeModal, handleDeleteUser })}

--- a/src/pages/privileges/outlets/users/tabs/users/EditUser/index.tsx
+++ b/src/pages/privileges/outlets/users/tabs/users/EditUser/index.tsx
@@ -1,8 +1,9 @@
 import { Link } from "react-router-dom";
-import { MdModeEdit } from "react-icons/md";
+import { MdOutlineEdit } from "react-icons/md";
 import { Button, Icon } from "@inube/design-system";
 
 import { IGeneralInformationEntry } from "../../../types/forms.types";
+import { useState } from "react";
 
 interface EditUserProps {
   entry: IGeneralInformationEntry;
@@ -10,22 +11,33 @@ interface EditUserProps {
 }
 function EditUser(props: EditUserProps) {
   const { entry, showComplete } = props;
+  const [isHovered, setIsHovered] = useState(false);
+
   return (
     <>
       {showComplete ? (
         <Button
-          iconBefore={<MdModeEdit />}
+          iconBefore={<MdOutlineEdit size={18} />}
           type="link"
           path={`edit/${entry.id}`}
-          variant="none"
-          appearance="gray"
+          variant="outline"
+          appearance="dark"
           spacing="compact"
         >
           Editar
         </Button>
       ) : (
-        <Link to={`edit/${entry.id}`}>
-          <Icon appearance="gray" size="20px" icon={<MdModeEdit />} />
+        <Link
+          to={`edit/${entry.id}`}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <Icon
+            appearance={isHovered ? "primary" : "dark"}
+            parentHover={isHovered ? true : false}
+            cursorHover
+            icon={<MdOutlineEdit />}
+          />
         </Link>
       )}
     </>


### PR DESCRIPTION
This PR addresses styling inconsistencies in the icons used within the `users` and `invitations` tables. Specifically, it corrects the icon versions from filled to outline, and updates the color tokens used for both hover and non-hover states. This change aligns the icons with our design system's guidelines, ensuring a consistent and visually coherent interface.