### PR TITLE
update `<Select />` layout in `<GeneralInformationFormUI />`

### DIFF
--- a/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/interface.tsx
@@ -168,17 +168,11 @@ function RenderFormFields(
       />
 
       <Stack direction="column" gap="8px">
-        <Text
-          type="label"
-          size="medium"
-          appearance={readOnly ? "gray" : "dark"}
-          padding="0px 0px 0px 16px"
-        >
-          Cargo
-        </Text>
         <Select
           name="position"
           id="position"
+          label="Cargo"
+          size="compact"
           required
           placeholder="Seleccione una opción"
           value={formik.values.position}


### PR DESCRIPTION
The `<Select />` component of Inube can render a Label and show that it is required, so it updates the use of the component's props to solve the layout problem between the `<Select />` label and whether it is `required`.  