### PR TITLE
`Fix:`  Correct Responsive Width Issue in Main Section of `<AppPage/>`

### DIFF
--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -37,6 +37,7 @@ function AppPage() {
         <StyledContainer>
           <Grid
             templateColumns={smallScreen ? "auto" : "auto 1fr"}
+            justifyContent={smallScreen ? "unset" : "start"}
             alignContent="unset"
           >
             {!smallScreen && (

--- a/src/components/navigation/Menu/styles.ts
+++ b/src/components/navigation/Menu/styles.ts
@@ -8,7 +8,7 @@ interface IStyledMenuProps {
 const StyledMenu = styled.div`
   position: absolute;
   right: 2%;
-  top: 55%;
+  top: 18rem;
 `;
 
 const StyledMenuContainer = styled.div`

--- a/src/components/navigation/Menu/styles.ts
+++ b/src/components/navigation/Menu/styles.ts
@@ -6,7 +6,9 @@ interface IStyledMenuProps {
 }
 
 const StyledMenu = styled.div`
-  position: relative;
+  position: absolute;
+  right: 2%;
+  top: 55%;
 `;
 
 const StyledMenuContainer = styled.div`


### PR DESCRIPTION
This PR addresses and resolves the issue with the width of the main section  `<AppPage/>`  in the responsive mode of our application. Currently, when the navigation is collapsed or removed in smaller screen sizes, the main section does not expand to utilize the full width of the screen, seemingly constrained by a maximum width setting. This fix ensures that the main section appropriately adjusts its width to provide a more optimized and visually appealing layout across various devices.