### PR TITLE
`Fix:` Ensure `<SectionMessage/>` Appears on Top of Content

### DIFF
--- a/src/pages/privileges/outlets/users/edit-user/forms/AidBudgetsForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/AidBudgetsForm/interface.tsx
@@ -6,6 +6,7 @@ import {
   IMessageState,
 } from "../../../types/forms.types";
 import { assignmentFormMessages } from "../../config/messages.config";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IMessageState,
@@ -19,16 +20,18 @@ const renderMessage = (
     assignmentFormMessages[message.type as keyof typeof assignmentFormMessages];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={onCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={onCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/AidBudgetsForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/AidBudgetsForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/edit-user/forms/BranchesForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/BranchesForm/interface.tsx
@@ -6,6 +6,7 @@ import {
   IAssignmentFormEntry,
   IMessageState,
 } from "../../../types/forms.types";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IMessageState,
@@ -19,16 +20,18 @@ const renderMessage = (
     assignmentFormMessages[message.type as keyof typeof assignmentFormMessages];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={onCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={onCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/BranchesForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/BranchesForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/edit-user/forms/EventsForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/EventsForm/interface.tsx
@@ -6,6 +6,7 @@ import {
   IMessageState,
 } from "../../../types/forms.types";
 import { assignmentFormMessages } from "../../config/messages.config";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IMessageState,
@@ -19,16 +20,18 @@ const renderMessage = (
     assignmentFormMessages[message.type as keyof typeof assignmentFormMessages];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={onCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={onCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/EventsForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/EventsForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/interface.tsx
@@ -19,6 +19,7 @@ import {
   IGeneralInformationEntry,
   IMessageState,
 } from "../../../types/forms.types";
+import { StyledMessageContainer } from "./styles";
 
 interface GeneralInformationFormUIProps {
   formik: FormikValues;
@@ -52,16 +53,18 @@ function renderMessages(
     generalInfoMessages[messageType];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={handleCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={handleCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 }
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/GeneralInfoForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/edit-user/forms/PayrollsForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/PayrollsForm/interface.tsx
@@ -6,6 +6,7 @@ import {
   IMessageState,
 } from "../../../types/forms.types";
 import { assignmentFormMessages } from "../../config/messages.config";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IMessageState,
@@ -19,16 +20,18 @@ const renderMessage = (
     assignmentFormMessages[message.type as keyof typeof assignmentFormMessages];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={onCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={onCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/PayrollsForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/PayrollsForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/edit-user/forms/ProjectsForm/interface.tsx
+++ b/src/pages/privileges/outlets/users/edit-user/forms/ProjectsForm/interface.tsx
@@ -6,6 +6,7 @@ import {
   IMessageState,
 } from "../../../types/forms.types";
 import { assignmentFormMessages } from "../../config/messages.config";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IMessageState,
@@ -18,16 +19,18 @@ const renderMessage = (
     assignmentFormMessages[message.type as keyof typeof assignmentFormMessages];
 
   return (
-    <Stack justifyContent="flex-end" width="100%">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={onCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={onCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/edit-user/forms/ProjectsForm/styles.ts
+++ b/src/pages/privileges/outlets/users/edit-user/forms/ProjectsForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/interface.tsx
+++ b/src/pages/privileges/outlets/users/interface.tsx
@@ -23,6 +23,7 @@ import { privilegeUserTabsConfig } from "./config/usersTabs.config";
 import { IUsersMessage } from "./types/users.types";
 import { InvitationsTab } from "./tabs/invitations";
 import { UsersTab } from "./tabs/users";
+import { StyledMessageContainer } from "./styles";
 
 const renderMessage = (
   message: IUsersMessage,
@@ -31,16 +32,18 @@ const renderMessage = (
   if (!message.data) return null;
 
   return (
-    <Stack justifyContent="flex-end" width="98%" margin="s800 s0">
-      <SectionMessage
-        title={message.data.title}
-        description={message.data.description}
-        icon={message.data.icon}
-        appearance={message.data.appearance}
-        duration={4000}
-        closeSectionMessage={handleCloseMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="98%">
+        <SectionMessage
+          title={message.data.title}
+          description={message.data.description}
+          icon={message.data.icon}
+          appearance={message.data.appearance}
+          duration={4000}
+          closeSectionMessage={handleCloseMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 };
 

--- a/src/pages/privileges/outlets/users/invite/interface.tsx
+++ b/src/pages/privileges/outlets/users/invite/interface.tsx
@@ -15,6 +15,7 @@ import { EMessageType } from "@src/types/messages.types";
 
 import { messageInvitationSentConfig } from "./config/messageInvitationSent.config";
 import { usersInvitationsConfig } from "./config/usersInvitations.config";
+import { StyledMessageContainer } from "./styles";
 
 interface InviteUIProps {
   formik: FormikValues;
@@ -45,16 +46,18 @@ function renderMessages(
     messageInvitationSentConfig[messageType];
 
   return (
-    <Stack justifyContent="flex-end" width="100%" margin="s800 s0">
-      <SectionMessage
-        title={title}
-        description={description}
-        icon={icon}
-        appearance={appearance}
-        duration={4000}
-        closeSectionMessage={handleCloseSectionMessage}
-      />
-    </Stack>
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          title={title}
+          description={description}
+          icon={icon}
+          appearance={appearance}
+          duration={4000}
+          closeSectionMessage={handleCloseSectionMessage}
+        />
+      </Stack>
+    </StyledMessageContainer>
   );
 }
 

--- a/src/pages/privileges/outlets/users/invite/styles.ts
+++ b/src/pages/privileges/outlets/users/invite/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/styles.ts
+++ b/src/pages/privileges/outlets/users/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/tabs/invitations/index.tsx
+++ b/src/pages/privileges/outlets/users/tabs/invitations/index.tsx
@@ -18,6 +18,7 @@ import { ResendInvitation } from "./ResendInvitation";
 import { EMessageType, IMessage } from "@src/types/messages.types";
 import { IGeneralInformationEntry } from "../../types/forms.types";
 import { EAppearance } from "@src/types/colors.types";
+import { StyledMessageContainer } from "./styles";
 
 const initialMessageState: IMessage = {
   show: false,
@@ -147,16 +148,18 @@ function InvitationsTab(props: InvitationsTabProps) {
         modalTitle="Invitación"
       />
       {message.show && (
-        <Stack justifyContent="flex-end" width="100%">
-          <SectionMessage
-            title={message.title}
-            description={message.description}
-            icon={message.icon}
-            appearance={message.appearance}
-            duration={4000}
-            closeSectionMessage={handleCloseMessage}
-          />
-        </Stack>
+        <StyledMessageContainer>
+          <Stack justifyContent="flex-end" width="100%">
+            <SectionMessage
+              title={message.title}
+              description={message.description}
+              icon={message.icon}
+              appearance={message.appearance}
+              duration={4000}
+              closeSectionMessage={handleCloseMessage}
+            />
+          </Stack>
+        </StyledMessageContainer>
       )}
     </>
   );

--- a/src/pages/privileges/outlets/users/tabs/invitations/styles.ts
+++ b/src/pages/privileges/outlets/users/tabs/invitations/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };

--- a/src/pages/privileges/outlets/users/tabs/users/index.tsx
+++ b/src/pages/privileges/outlets/users/tabs/users/index.tsx
@@ -18,6 +18,7 @@ import { EditUser } from "./EditUser";
 import { IGeneralInformationEntry } from "../../types/forms.types";
 import { EAppearance } from "@src/types/colors.types";
 import { EMessageType, IMessage } from "@src/types/messages.types";
+import { StyledMessageContainer } from "./styles";
 
 const initialMessageState: IMessage = {
   show: false,
@@ -152,16 +153,18 @@ function UsersTab(props: UsersTabProps) {
         modalTitle="Usuario"
       />
       {message.show && (
-        <Stack justifyContent="flex-end" width="100%">
-          <SectionMessage
-            title={message.title}
-            description={message.description}
-            icon={message.icon}
-            appearance={message.appearance}
-            duration={4000}
-            closeSectionMessage={onCloseMessage}
-          />
-        </Stack>
+        <StyledMessageContainer>
+          <Stack justifyContent="flex-end" width="100%">
+            <SectionMessage
+              title={message.title}
+              description={message.description}
+              icon={message.icon}
+              appearance={message.appearance}
+              duration={4000}
+              closeSectionMessage={onCloseMessage}
+            />
+          </Stack>
+        </StyledMessageContainer>
       )}
     </>
   );

--- a/src/pages/privileges/outlets/users/tabs/users/styles.ts
+++ b/src/pages/privileges/outlets/users/tabs/users/styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+export { StyledMessageContainer };


### PR DESCRIPTION
This PR addresses a layout issue with the `<SectionMessage/>` component, where it is not correctly positioned above the other content elements. The goal is to adjust the `<SectionMessage/>` component's positioning so that it consistently appears on top, enhancing visibility and ensuring it serves its intended purpose effectively.