### PR TITLE
`<UsersUI />`: the users and invitations tab shouldn't use a select tab in mobile

### DIFF
--- a/src/pages/privileges/outlets/users/interface.tsx
+++ b/src/pages/privileges/outlets/users/interface.tsx
@@ -92,7 +92,6 @@ export function UsersUI(props: UsersUIProps) {
               tabs={Object.values(privilegeUserTabsConfig)}
               selectedTab={isSelected}
               onChange={handleTabChange}
-              type={smallScreen ? "select" : "tabs"}
             />
             <Stack justifyContent="space-between" alignItems="center">
               <Textfield


### PR DESCRIPTION
Checking the mockups, the design considered that even for mobile, the tabs for users and invitations fit in the screen in the normal layout of the component, without shifting to select mode.
Refactor the usage of the component so that stick to what is defined in the mockups.