### PR TITLE
Create Menu for selecting palette color tokens

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,2 +1,3 @@
 <div id="portal"></div>
 <div id="decision"></div>
+<div id="palette"></div>

--- a/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
+++ b/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
@@ -1,7 +1,11 @@
 import { BrowserRouter } from "react-router-dom";
 import { StoryFn } from "@storybook/react";
-
+import { inube } from "@inube/design-system";
 import { FieldsetColorCard, FieldsetColorCardProps } from ".";
+import { useState } from "react";
+import React from "react";
+import { Appearance } from "./types";
+import { getTokenColor } from "./styles";
 
 const story = {
   component: [FieldsetColorCard],
@@ -15,8 +19,47 @@ const story = {
   ],
 };
 
+const FieldsetColorCardWrapper = ({
+  children,
+  appearance,
+  category,
+  initialPalette,
+}: {
+  children: React.ReactNode;
+  appearance: Appearance;
+  category: string;
+  initialPalette: typeof inube.color.palette;
+}) => {
+  const [palette, setPalette] = useState(initialPalette);
+  const [textConfig, setTextConfig] = useState(inube.color.text);
+  const handleTokenChange = (updatedTokenName: string) => {
+    const updatedTextConfig = { ...textConfig };
+    if (
+      updatedTextConfig[appearance] &&
+      updatedTextConfig[appearance][category]
+    ) {
+      updatedTextConfig[appearance][category] = getTokenColor(updatedTokenName);
+    }
+    setTextConfig(updatedTextConfig);
+  };
+
+  return React.cloneElement(children as React.ReactElement<any>, {
+    appearance,
+    category,
+    palette,
+    onChange: handleTokenChange,
+    textConfig,
+  });
+};
+
 const Template: StoryFn<FieldsetColorCardProps> = (args) => (
-  <FieldsetColorCard {...args} />
+  <FieldsetColorCardWrapper
+    appearance={args.appearance}
+    category={args.category}
+    initialPalette={inube.color.palette}
+  >
+    <FieldsetColorCard {...args} />
+  </FieldsetColorCardWrapper>
 );
 
 export const Default = Template.bind({});
@@ -24,9 +67,11 @@ Default.args = {
   title: "Regular",
   description:
     "El texto tendrá este color cuando no tenga cambios por comportamiento o interacción con el usuario.",
-  tokenName: "B400",
-  tokenDescription:
+  textWithColorToken:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tempor mauris a nisl auctor posuere. In eu metus dapibus, tristique felis sit amet, convallis ligula.",
+  appearance: "primary",
+  category: "regular",
+  palette: inube.color.palette,
 };
 
 export default story;

--- a/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
+++ b/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
@@ -30,7 +30,6 @@ const FieldsetColorCardWrapper = ({
   category: string;
   initialPalette: typeof inube.color.palette;
 }) => {
-  const [palette, setPalette] = useState(initialPalette);
   const [textConfig, setTextConfig] = useState(inube.color.text);
   const handleTokenChange = (updatedTokenName: string) => {
     const updatedTextConfig = { ...textConfig };
@@ -46,9 +45,8 @@ const FieldsetColorCardWrapper = ({
   return React.cloneElement(children as React.ReactElement<any>, {
     appearance,
     category,
-    palette,
+    initialPalette,
     onChange: handleTokenChange,
-    textConfig,
   });
 };
 

--- a/src/components/cards/FieldsetColorCard/index.tsx
+++ b/src/components/cards/FieldsetColorCard/index.tsx
@@ -1,65 +1,88 @@
-import { Stack, Text, useMediaQuery, inube } from "@inube/design-system";
-import { useRef, useState } from "react";
+import { Stack, Text, inube } from "@inube/design-system";
 
-import { StyledTokenColorCardContainer } from "./styles";
+import { StyledTokenColorCardContainer, StyledPopupContainer } from "./styles";
 import { Fieldset } from "@src/components/inputs/Fieldset";
 import { TokenColorCard } from "../TokenColorCard";
+import { Appearance } from "./types";
 
 interface FieldsetColorCardProps {
   title: string;
   description: string;
-  tokenName: string;
-  tokenDescription: string;
-  onChange: (tokenName: string, color: string) => void;
+  appearance: Appearance;
+  category: string;
+  textWithColorToken: string;
+  palette: typeof inube;
+  onChange: (tokenName: string) => void;
 }
 
-const mapTokenToCategoryAndState = (tokenName: string | number) => {
-  const textTokens = inube.color.text;
-  for (const category in textTokens) {
-    for (const status in textTokens[category]) {
-      if (
-        Object.values(inube.color.palette).some(
-          (colorGroup: any) =>
-            colorGroup[tokenName] === textTokens[category][status]
-        )
-      ) {
-        return { category, status };
+const getTokenReferenceFromAppearanceAndCategory = (
+  appearance: Appearance,
+  category: string
+) => {
+  const tokenReference = inube.color.text[appearance]?.[category];
+  if (!tokenReference) return null;
+  const castedPalette = inube.color.palette as Record<
+    string,
+    Record<string, string>
+  >;
+  for (const [, colorValues] of Object.entries(castedPalette)) {
+    for (const [colorKey, colorValue] of Object.entries(colorValues)) {
+      if (colorValue === tokenReference) {
+        return colorKey;
       }
     }
   }
-  return { category: null, status: null };
+  return null;
 };
 
 function FieldsetColorCard(props: FieldsetColorCardProps) {
-  const { title, description, tokenName, tokenDescription, onChange } = props;
+  const {
+    title,
+    description,
+    appearance,
+    category,
+    textWithColorToken,
+    palette,
+    onChange,
+  } = props;
 
-  const { category, status } = mapTokenToCategoryAndState(tokenName);
+  const tokenName = getTokenReferenceFromAppearanceAndCategory(
+    appearance,
+    category
+  );
+
+  const handleColorChange = (updatedTokenName: string) => {
+    onChange(updatedTokenName);
+  };
 
   return (
     <Fieldset title={title}>
-      <Stack direction="column" gap={inube.spacing.s200}>
-        <Text size="medium" appearance="gray">
-          {description}
-        </Text>
-        <Stack gap={inube.spacing.s200} alignItems="center">
-          <StyledTokenColorCardContainer>
-            <TokenColorCard
-              tokenName={tokenName}
-              onColorChange={(tokenName, newColor) =>
-                onChange(tokenName, newColor)
-              }
-            />
-          </StyledTokenColorCardContainer>
-          <Text
-            size="medium"
-            appearance={category}
-            parentHover={status === "hover"}
-            disabled={status === "disabled"}
-          >
-            {tokenDescription}
+      <>
+        <Stack direction="column" gap={inube.spacing.s200}>
+          <Text size="medium" appearance="gray">
+            {description}
           </Text>
+          <Stack gap={inube.spacing.s200} alignItems="center">
+            <StyledTokenColorCardContainer>
+              <TokenColorCard
+                tokenName={tokenName!}
+                type="tokenPicker"
+                palette={palette}
+                onColorChange={handleColorChange}
+              />
+            </StyledTokenColorCardContainer>
+            <Text
+              size="medium"
+              appearance={appearance}
+              parentHover={category === "hover"}
+              disabled={category === "disabled"}
+            >
+              {textWithColorToken}
+            </Text>
+          </Stack>
         </Stack>
-      </Stack>
+        <StyledPopupContainer id="palette"></StyledPopupContainer>
+      </>
     </Fieldset>
   );
 }

--- a/src/components/cards/FieldsetColorCard/styles.ts
+++ b/src/components/cards/FieldsetColorCard/styles.ts
@@ -9,17 +9,36 @@ interface IStyledFieldsetColorCard {
   smallScreen: boolean;
 }
 
+function getTokenColor(tokenName: string, theme?: typeof inube) {
+  const palette = theme?.color?.palette || inube.color.palette;
+  for (const category in palette) {
+    if (Object.hasOwnProperty.call(palette[category], tokenName)) {
+      return palette[category!]?.[tokenName];
+    }
+  }
+}
+
 const StyledTokenColorCardContainer = styled.div`
   width: 100%;
   max-width: ${inube.spacing.s1000};
-  & div {
+  & > div {
     width: 100%;
     height: 24px;
     max-width: 80px;
-    & div {
-      padding: 0px 12px;
+    & > div {
+      justify-content: center;
+      padding: 4px;
     }
   }
 `;
 
-export { StyledTokenColorCardContainer };
+const StyledPopupContainer = styled.div`
+  & > div > div {
+    height: 100%;
+    width: 100%;
+    max-width: 350px;
+    max-height: 400px;
+  }
+`;
+
+export { StyledTokenColorCardContainer, StyledPopupContainer, getTokenColor };

--- a/src/components/cards/FieldsetColorCard/types.ts
+++ b/src/components/cards/FieldsetColorCard/types.ts
@@ -1,0 +1,3 @@
+import { inube } from "@inube/design-system";
+
+export type Appearance = keyof typeof inube.color.text;

--- a/src/components/cards/TokenColorCard/TokenColorCard.stories.tsx
+++ b/src/components/cards/TokenColorCard/TokenColorCard.stories.tsx
@@ -8,6 +8,17 @@ const story = {
   component: [TokenColorCard],
   title: "components/cards/TokenColorCard",
   decorators: [(Story: StoryFn) => <Story />],
+  argTypes: {
+    type: {
+      options: ["colorPicker", "tokenPicker"],
+      control: { type: "select" },
+      description:
+        "It is the type of TokenColorCard be operate if a colorPicker or as a tokenPicker",
+      table: {
+        defaultValue: { summary: "colorPicker" },
+      },
+    },
+  },
 };
 
 const Template: StoryFn<ITokenColorCardProps> = (args) => (
@@ -19,23 +30,32 @@ const theme = {
 };
 const DynamicThemeWrapper = ({ children }: any) => {
   const [theme, setTheme] = useState({ ...inube.color.palette });
+  const [selectedTokenName, setSelectedTokenName] = useState("N900");
 
   const handleColorChange = (tokenName: string, newColor: string) => {
-    setTheme((prevTheme: typeof inube) => {
-      const newPalette = { ...prevTheme };
-      for (const category in newPalette) {
-        if (newPalette[category][tokenName]) {
-          newPalette[category][tokenName] = newColor;
-          break;
+    if (newColor) {
+      setTheme((prevTheme: typeof inube) => {
+        const newPalette = { ...prevTheme };
+        for (const category in newPalette) {
+          if (newPalette[category][tokenName]) {
+            newPalette[category][tokenName] = newColor;
+            break;
+          }
         }
-      }
-      return newPalette;
-    });
+        return newPalette;
+      });
+    } else {
+      console.log("Token Name Change Detected:", tokenName);
+      setSelectedTokenName(tokenName);
+    }
   };
 
   return (
     <ThemeProvider theme={theme}>
-      {React.cloneElement(children, { onColorChange: handleColorChange })}
+      {React.cloneElement(children, {
+        onColorChange: handleColorChange,
+        tokenName: selectedTokenName,
+      })}
     </ThemeProvider>
   );
 };
@@ -49,5 +69,7 @@ export const Default = (args: ITokenColorCardProps) => (
 Default.args = {
   tokenName: "N900",
   tokenDescription: "Color token",
+  type: "tokenPicker",
+  palette: inube.color.palette,
 };
 export default story;

--- a/src/components/cards/TokenColorCard/index.tsx
+++ b/src/components/cards/TokenColorCard/index.tsx
@@ -1,24 +1,91 @@
-import { Stack, Text, useMediaQuery } from "@inube/design-system";
+import { Stack, Text, useMediaQuery, Grid, inube } from "@inube/design-system";
 import { useContext, useRef, useState } from "react";
 import tinycolor from "tinycolor2";
 import {
   StyledColorTokenCard,
   HiddenColorPicker,
+  StyledGridContainer,
+  StyledGridColorsContainer,
   getTokenColor,
 } from "./styles";
 import { ThemeContext } from "styled-components";
+import { Popup } from "@src/components/feedback/Popup";
+import { categoryTranslations } from "@src/pages/people/outlets/palette/config/palette.config";
 
 interface ITokenColorCardProps {
-  onColorChange: (tokenName: string, newColor: string) => void;
   tokenName: string;
   tokenDescription?: string;
-  size?: string;
+  type?: "colorPicker" | "tokenPicker";
+  palette?: typeof inube;
+  onColorChange: (tokenName: string, newColor?: string) => void;
+}
+
+interface renderCategoryGridProps {
+  categories: typeof inube;
+  templateColumns: string;
+  templateRows?: string;
+  autoFlow?: string;
+  hasBackground?: boolean;
+  onChange: any;
+}
+
+function RenderCategoryGrid(props: renderCategoryGridProps) {
+  const {
+    categories,
+    templateColumns,
+    templateRows = "auto",
+    autoFlow = "row",
+    hasBackground = false,
+    onChange,
+  } = props;
+
+  return categories.map(([category, tokens]: string) => (
+    <Stack key={category} gap="16px" direction="column">
+      <Text
+        type="title"
+        size="medium"
+        padding="0px 0px 0px 0px"
+        textAlign="start"
+        appearance="dark"
+      >
+        {categoryTranslations[category] || category}
+      </Text>
+      <StyledGridContainer hasBackground={hasBackground}>
+        <Grid
+          templateColumns={templateColumns}
+          templateRows={templateRows}
+          gap="s050"
+          autoColumns="unset"
+          autoRows="unset"
+          autoFlow={autoFlow}
+        >
+          {Object.entries(tokens).map(([tokenName]) => (
+            <div key={tokenName} onClick={() => onChange(tokenName)}>
+              <TokenColorCard
+                tokenName={tokenName}
+                palette={categories}
+                type="tokenPicker"
+                tokenDescription={"Token de color"}
+                onColorChange={() => onChange(tokenName)}
+              />
+            </div>
+          ))}
+        </Grid>
+      </StyledGridContainer>
+    </Stack>
+  ));
 }
 
 function TokenColorCard(props: ITokenColorCardProps) {
-  const { tokenName, tokenDescription, onColorChange } = props;
+  const {
+    tokenName,
+    tokenDescription,
+    type = "colorPicker",
+    palette,
+    onColorChange,
+  } = props;
   const theme = useContext(ThemeContext);
-
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isActive, setIsActive] = useState(false);
 
   const smallScreen = useMediaQuery("(max-width: 970px)");
@@ -29,6 +96,7 @@ function TokenColorCard(props: ITokenColorCardProps) {
 
   const handleToggleModal = () => {
     setIsActive(!isActive);
+    setIsPopupOpen(!isActive);
     if (colorPickerRef.current) {
       colorPickerRef.current.click();
     }
@@ -39,6 +107,10 @@ function TokenColorCard(props: ITokenColorCardProps) {
   ) => {
     const newColor = event.target.value;
     onColorChange(tokenName, newColor);
+  };
+
+  const handleColorChangeCategory = (tokenName: string) => {
+    onColorChange(tokenName);
   };
 
   return (
@@ -84,11 +156,35 @@ function TokenColorCard(props: ITokenColorCardProps) {
                 </Text>
               </>
             )}
-            <HiddenColorPicker
-              ref={colorPickerRef}
-              value={getTokenColor(tokenName, theme)}
-              onChange={handleColorChangeLocal}
-            />
+            {type === "colorPicker" && (
+              <HiddenColorPicker
+                ref={colorPickerRef}
+                value={getTokenColor(tokenName, theme)}
+                onChange={handleColorChangeLocal}
+              />
+            )}
+            {isPopupOpen && type === "tokenPicker" && (
+              <Popup
+                portalId="palette"
+                closeModal={() => setIsPopupOpen(false)}
+                title={"Paleta de colores"}
+              >
+                <StyledGridColorsContainer>
+                  <Grid
+                    templateColumns="repeat(auto-fit, minmax(250px, 1fr))"
+                    gap="s150"
+                    autoColumns="unset"
+                    autoRows="unset"
+                  >
+                    <RenderCategoryGrid
+                      categories={Object.entries(palette)}
+                      templateColumns="repeat(auto-fit, minmax(250px, 1fr))"
+                      onChange={handleColorChangeCategory}
+                    />
+                  </Grid>
+                </StyledGridColorsContainer>
+              </Popup>
+            )}
           </Stack>
         </Stack>
       </StyledColorTokenCard>

--- a/src/components/cards/TokenColorCard/styles.ts
+++ b/src/components/cards/TokenColorCard/styles.ts
@@ -7,6 +7,11 @@ interface IStyledColorTokenCard {
   smallScreen: boolean;
 }
 
+interface StyledPaletteUI {
+  theme?: typeof inube;
+  hasBackground: boolean;
+}
+
 function getTokenColor(tokenName: string, theme: typeof inube) {
   const palette = theme?.color?.palette || inube.color.palette;
   for (const category in palette) {
@@ -35,4 +40,27 @@ const StyledColorTokenCard = styled.div<IStyledColorTokenCard>`
     getTokenColor(tokenName, theme)};
 `;
 
-export { StyledColorTokenCard, HiddenColorPicker, getTokenColor };
+const StyledGridContainer = styled.div<StyledPaletteUI>`
+  background-color: ${({ theme, hasBackground }) =>
+    hasBackground
+      ? theme?.color?.surface?.dark?.clear || inube.color.surface.dark.clear
+      : "unset"};
+  border-radius: ${inube.spacing.s100};
+  padding: ${({ hasBackground }) =>
+    hasBackground ? inube.spacing.s150 : inube.spacing.s0};
+  & div {
+    place-content: unset;
+  }
+`;
+
+const StyledGridColorsContainer = styled.div`
+  overflow: auto;
+`;
+
+export {
+  StyledColorTokenCard,
+  HiddenColorPicker,
+  StyledGridContainer,
+  StyledGridColorsContainer,
+  getTokenColor,
+};

--- a/src/components/feedback/Popup/Popup.stories.tsx
+++ b/src/components/feedback/Popup/Popup.stories.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@inube/design-system";
+import { useState } from "react";
+import { Popup } from ".";
+import { PopupProps } from "./types";
+
+const story = {
+  title: "Components/Feedback/Popup",
+  component: Popup,
+};
+
+const data = {
+  id: 10,
+  userID: "45645",
+  username: "David Leonardo Garzón",
+  mail: "lgarzon@gmail.com",
+  invitationDate: "11/JUN/2022",
+  status: "Sent",
+};
+
+export const Default = (args: PopupProps) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setShowModal(true)}>Show Popup</Button>
+      {showModal && <Popup {...args} closeModal={() => setShowModal(false)} />}
+    </>
+  );
+};
+
+Default.args = {
+  portalId: "portal",
+  title: "Paleta de colores",
+};
+
+export default story;

--- a/src/components/feedback/Popup/index.tsx
+++ b/src/components/feedback/Popup/index.tsx
@@ -1,0 +1,46 @@
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import { Stack, Text, Icon } from "@inube/design-system";
+import { StyledPopup } from "./styles";
+import { PopupProps } from "./types";
+
+const Popup = (props: PopupProps) => {
+  const { portalId, title, closeModal, children } = props;
+  const node = document.getElementById(portalId);
+
+  if (!node) {
+    throw new Error(
+      "The portal node is not defined. This can occur when the specific node used to render the portal has not been defined correctly."
+    );
+  }
+
+  return createPortal(
+    <StyledPopup>
+      <Stack
+        width="350px"
+        height="500px"
+        padding="s300"
+        direction="column"
+        gap="20px"
+      >
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small" appearance="dark">
+            {title}
+          </Text>
+          <Icon
+            appearance={"dark"}
+            icon={<MdClear />}
+            spacing="wide"
+            size="24px"
+            cursorHover
+            onClick={closeModal}
+          />
+        </Stack>
+        {children}
+      </Stack>
+    </StyledPopup>,
+    node
+  );
+};
+
+export { Popup };

--- a/src/components/feedback/Popup/styles.ts
+++ b/src/components/feedback/Popup/styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import { inube } from "@inube/design-system";
+
+interface IStyledPopup {
+  theme?: typeof inube;
+}
+
+const StyledPopup = styled.div<IStyledPopup>`
+  & > div {
+    position: absolute;
+    border-radius: ${inube.spacing.s100};
+    background-color: ${({ theme }: IStyledPopup) =>
+      theme?.color?.surface?.light?.regular ||
+      inube.color.surface.light.regular};
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.3),
+      0px 4px 8px 3px rgba(0, 0, 0, 0.15);
+    z-index: 2;
+  }
+`;
+
+export { StyledPopup };

--- a/src/components/feedback/Popup/types.ts
+++ b/src/components/feedback/Popup/types.ts
@@ -1,0 +1,8 @@
+interface PopupProps {
+  portalId: string;
+  title: string;
+  closeModal: () => void;
+  children: React.ReactNode;
+}
+
+export type { PopupProps };

--- a/src/components/forms/submit/FormButtons/index.tsx
+++ b/src/components/forms/submit/FormButtons/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack } from "@inube/design-system";
+import { Button, Stack, inube } from "@inube/design-system";
 
 interface FormButtonsProps {
   children: React.ReactNode;
@@ -13,7 +13,7 @@ function FormButtons(props: FormButtonsProps) {
     props;
 
   return (
-    <Stack direction="column">
+    <Stack direction="column" gap={inube.spacing.s300}>
       <Stack>{children}</Stack>
       <Stack justifyContent="flex-end" gap="16px" margin="s100 s0 s0 s0">
         <Button
@@ -25,7 +25,7 @@ function FormButtons(props: FormButtonsProps) {
           Cancelar
         </Button>
         <Button
-          appearance="success"
+          appearance="primary"
           onClick={handleSubmit}
           loading={loading}
           disabled={disabledButtons}

--- a/src/pages/people/outlets/palette/index.tsx
+++ b/src/pages/people/outlets/palette/index.tsx
@@ -12,7 +12,10 @@ function Palette() {
     visible: false,
   });
 
-  const handleColorChange = (tokenName: string, newColor: string) => {
+  const handleColorChange = (
+    tokenName: string,
+    newColor: string | undefined
+  ) => {
     setColorTokens((prevTokens: typeof inube) => {
       const newTokens = { ...prevTokens };
       for (const category in newTokens) {

--- a/src/pages/people/outlets/palette/interface.tsx
+++ b/src/pages/people/outlets/palette/interface.tsx
@@ -100,7 +100,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
               tokenName={tokenName}
               tokenDescription={"Token de color"}
               onColorChange={(tokenName, newColor) =>
-                handleColorChange(tokenName, newColor)
+                handleColorChange(tokenName, newColor!)
               }
             />
           ))}

--- a/src/pages/people/outlets/texts/form/DarkForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/DarkForm/index.tsx
@@ -10,41 +10,33 @@ import {
 const LOADING_TIMEOUT = 1500;
 
 interface DarkFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  textConfig: any;
+  handleSubmit: (darkText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function DarkForm(props: DarkFormProps) {
-  const {
-    currentAidBudgetUnits,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const { textConfig, handleSubmit, onHasChanges } = props;
+  const [darkText, setDarkText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeDark = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeDark = (darkText: IAssignmentFormEntry[]) => {
+    setDarkText(darkText);
+    if (onHasChanges) onHasChanges(hasChanges(darkText));
+    handleSubmit(darkText);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(darkText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +46,7 @@ function DarkForm(props: DarkFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setDarkText(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -70,12 +62,10 @@ function DarkForm(props: DarkFormProps) {
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
+      textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/DarkForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/DarkForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { DarkFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,12 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface DarkFormProps {
   textConfig: any;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (darkText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
 }
 
 function DarkForm(props: DarkFormProps) {
-  const { textConfig, handleSubmit, onHasChanges } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [darkText, setDarkText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -58,10 +60,11 @@ function DarkForm(props: DarkFormProps) {
 
   return (
     <DarkFormUI
-      handleChangeDark={handleChangeDark}
+      handleChangeDark={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
+      palette={palette}
       textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}

--- a/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
@@ -39,37 +39,34 @@ const renderMessage = (
 };
 
 interface DarkFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
   handleChangeDark: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
 function DarkFormUI(props: DarkFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
     handleChangeDark,
-    withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
-  const darkConfig = Object.entries(textFormsConfig.dark.status);
+
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
         disabledButtons={false}
@@ -78,14 +75,14 @@ function DarkFormUI(props: DarkFormUIProps) {
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {darkConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}
               description={config.description}
               tokenName={config.tokenName}
               tokenDescription={config.example}
-              onClick={function (tokenName: string, color: string): void {
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
@@ -8,7 +8,6 @@ import {
   IMessageState,
 } from "@src/pages/privileges/outlets/users/types/forms.types";
 import { assignmentFormMessages } from "@src/pages/privileges/outlets/users/edit-user/config/messages.config";
-import { textFormsConfig } from "../../config/text.config";
 import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
 
 const renderMessage = (
@@ -41,9 +40,10 @@ const renderMessage = (
 interface DarkFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeDark: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+  handleChangeDark: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
@@ -55,6 +55,7 @@ function DarkFormUI(props: DarkFormUIProps) {
     isLoading,
     handleSubmitForm,
     handleReset,
+    palette,
     handleChangeDark,
     message,
     onCloseSectionMessage,
@@ -78,13 +79,15 @@ function DarkFormUI(props: DarkFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"dark"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeDark("dark", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/ErrorForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/ErrorForm/index.tsx
@@ -12,13 +12,13 @@ const LOADING_TIMEOUT = 1500;
 interface ErrorTokensFormProps {
   textConfig: any;
   palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function ErrorForm(props: ErrorTokensFormProps) {
-  const { textConfig, palette, handleSubmit, onHasChanges, readOnly } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [errorText, setErrorText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -28,9 +28,6 @@ function ErrorForm(props: ErrorTokensFormProps) {
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
     JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeErrorTokens = (key: string, tokenName: string) => {
-    setErrorText((prevNames: any) => ({ ...prevNames, [key]: tokenName }));
-  };
   const handleSubmitForm = () => {
     setIsLoading(true);
 
@@ -58,7 +55,7 @@ function ErrorForm(props: ErrorTokensFormProps) {
   return (
     <ErrorFormUI
       textConfig={textConfig}
-      handleChangeErrorTokens={handleChangeErrorTokens}
+      handleChangeErrorTokens={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}

--- a/src/pages/people/outlets/texts/form/ErrorForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/ErrorForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ErrorFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -9,22 +9,16 @@ import {
 
 const LOADING_TIMEOUT = 1500;
 
-interface AidBudgetsFormProps {
+interface ErrorTokensFormProps {
   textConfig: any;
+  palette: typeof inube;
   handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
   readOnly?: boolean;
 }
 
-function ErrorForm(props: AidBudgetsFormProps) {
-  const {
-    textConfig,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
+function ErrorForm(props: ErrorTokensFormProps) {
+  const { textConfig, palette, handleSubmit, onHasChanges, readOnly } = props;
   const [errorText, setErrorText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -34,12 +28,9 @@ function ErrorForm(props: AidBudgetsFormProps) {
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
     JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeAidBudgets = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setErrorText(errorText);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeErrorTokens = (key: string, tokenName: string) => {
+    setErrorText((prevNames: any) => ({ ...prevNames, [key]: tokenName }));
   };
-
   const handleSubmitForm = () => {
     setIsLoading(true);
 
@@ -67,18 +58,17 @@ function ErrorForm(props: AidBudgetsFormProps) {
   return (
     <ErrorFormUI
       textConfig={textConfig}
-      handleChangeAidBudgets={handleChangeAidBudgets}
+      handleChangeErrorTokens={handleChangeErrorTokens}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      withSubmitButtons={withSubmitButtons}
+      palette={palette}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }
 
-export type { AidBudgetsFormProps };
+export type { ErrorTokensFormProps };
 export { ErrorForm };

--- a/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
@@ -10,6 +10,7 @@ import {
 import { assignmentFormMessages } from "@src/pages/privileges/outlets/users/edit-user/config/messages.config";
 import { textFormsConfig } from "../../config/text.config";
 import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
+import { Appearance } from "@src/components/cards/FieldsetColorCard/types";
 
 const renderMessage = (
   message: IMessageState,
@@ -44,7 +45,11 @@ interface ErrorTokensFormUIProps {
   palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeErrorTokens: (tokenName: string, newColor: string) => void;
+  handleChangeErrorTokens: (
+    appearance: Appearance,
+    category: string,
+    tokenName: string
+  ) => void;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
@@ -83,11 +88,11 @@ function ErrorFormUI(props: ErrorTokensFormUIProps) {
               palette={palette}
               title={config.title}
               description={config.description}
-              appearance={"primary"}
+              appearance={"error"}
               category={key}
               textWithColorToken={config.example}
               onChange={(newTokenName) =>
-                handleChangeErrorTokens(key, newTokenName)
+                handleChangeErrorTokens("error", key, newTokenName)
               }
             />
           ))}

--- a/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
@@ -13,7 +13,7 @@ import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
 
 const renderMessage = (
   message: IMessageState,
-  onCloseSectionMessage: AidBudgetsFormUIProps["onCloseSectionMessage"]
+  onCloseSectionMessage: ErrorTokensFormUIProps["onCloseSectionMessage"]
 ) => {
   if (!message.visible || !message.type) {
     return null;
@@ -38,31 +38,29 @@ const renderMessage = (
   );
 };
 
-interface AidBudgetsFormUIProps {
+interface ErrorTokensFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeAidBudgets: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  handleChangeErrorTokens: (tokenName: string, newColor: string) => void;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
-function ErrorFormUI(props: AidBudgetsFormUIProps) {
+function ErrorFormUI(props: ErrorTokensFormUIProps) {
   const {
     textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
-    handleChangeAidBudgets,
-    withSubmitButtons,
+    handleChangeErrorTokens,
+    palette,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
 
   const colorCards = Object.entries(textConfig.status);
@@ -73,7 +71,7 @@ function ErrorFormUI(props: AidBudgetsFormUIProps) {
         {textConfig.description}
       </Text>
       <FormButtons
-        disabledButtons={false}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
@@ -82,11 +80,15 @@ function ErrorFormUI(props: AidBudgetsFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={() => {}}
+              appearance={"primary"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeErrorTokens(key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/GrayForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/GrayForm/index.tsx
@@ -10,41 +10,33 @@ import {
 const LOADING_TIMEOUT = 1500;
 
 interface GrayFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  textConfig: any;
+  handleSubmit: (grayText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function GrayForm(props: GrayFormProps) {
-  const {
-    currentAidBudgetUnits,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const { textConfig, handleSubmit, onHasChanges } = props;
+  const [grayText, setGrayText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeGray = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeGray = (grayText: IAssignmentFormEntry[]) => {
+    setGrayText(grayText);
+    if (onHasChanges) onHasChanges(hasChanges(grayText));
+    handleSubmit(grayText);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(grayText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +46,7 @@ function GrayForm(props: GrayFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setGrayText(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -70,12 +62,10 @@ function GrayForm(props: GrayFormProps) {
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
+      textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/GrayForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/GrayForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { GrayFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,12 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface GrayFormProps {
   textConfig: any;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (grayText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
 }
 
 function GrayForm(props: GrayFormProps) {
-  const { textConfig, handleSubmit, onHasChanges } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [grayText, setGrayText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -58,10 +60,11 @@ function GrayForm(props: GrayFormProps) {
 
   return (
     <GrayFormUI
-      handleChangeGray={handleChangeGray}
+      handleChangeGray={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
+      palette={palette}
       textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}

--- a/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
@@ -39,47 +39,43 @@ const renderMessage = (
 };
 
 interface GrayFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
   handleChangeGray: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
 function GrayFormUI(props: GrayFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
     handleChangeGray,
-    withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
 
-  const grayConfig = Object.entries(textFormsConfig.gray.status);
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
-        disabledButtons={false}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {grayConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}

--- a/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
@@ -41,9 +41,10 @@ const renderMessage = (
 interface GrayFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeGray: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+  handleChangeGray: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
@@ -53,6 +54,7 @@ function GrayFormUI(props: GrayFormUIProps) {
   const {
     textConfig,
     isLoading,
+    palette,
     handleSubmitForm,
     handleReset,
     handleChangeGray,
@@ -78,11 +80,15 @@ function GrayFormUI(props: GrayFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={() => {}}
+              appearance={"gray"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeGray("gray", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/HelpForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/HelpForm/index.tsx
@@ -10,41 +10,33 @@ import {
 const LOADING_TIMEOUT = 1500;
 
 interface HelpFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  textConfig: any;
+  handleSubmit: (helpText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function HelpForm(props: HelpFormProps) {
-  const {
-    currentAidBudgetUnits,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const { textConfig, handleSubmit, onHasChanges } = props;
+  const [helpText, setHelpText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(helpText) !== JSON.stringify(valueCompare);
 
-  const handleChangeHelp = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeHelp = (helpText: IAssignmentFormEntry[]) => {
+    setHelpText(helpText);
+    if (onHasChanges) onHasChanges(hasChanges(helpText));
+    handleSubmit(helpText);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(helpText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +46,7 @@ function HelpForm(props: HelpFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setHelpText(helpText);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -69,13 +61,11 @@ function HelpForm(props: HelpFormProps) {
       handleChangeHelp={handleChangeHelp}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
+      textConfig={textConfig}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/HelpForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/HelpForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { HelpFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,12 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface HelpFormProps {
   textConfig: any;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (helpText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
 }
 
 function HelpForm(props: HelpFormProps) {
-  const { textConfig, handleSubmit, onHasChanges } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [helpText, setHelpText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -58,10 +60,11 @@ function HelpForm(props: HelpFormProps) {
 
   return (
     <HelpFormUI
-      handleChangeHelp={handleChangeHelp}
+      handleChangeHelp={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       textConfig={textConfig}
+      palette={palette}
       isLoading={isLoading}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}

--- a/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
@@ -41,9 +41,10 @@ const renderMessage = (
 interface HelpFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeHelp: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+  handleChangeHelp: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
@@ -55,6 +56,7 @@ function HelpFormUI(props: HelpFormUIProps) {
     isLoading,
     handleSubmitForm,
     handleReset,
+    palette,
     handleChangeHelp,
     message,
     onCloseSectionMessage,
@@ -78,13 +80,15 @@ function HelpFormUI(props: HelpFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"help"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeHelp("help", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
@@ -39,37 +39,34 @@ const renderMessage = (
 };
 
 interface HelpFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
   handleChangeHelp: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
 function HelpFormUI(props: HelpFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
     handleChangeHelp,
-    withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
-  const helpConfig = Object.entries(textFormsConfig.help.status);
+
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
         disabledButtons={false}
@@ -78,14 +75,14 @@ function HelpFormUI(props: HelpFormUIProps) {
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {helpConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}
               description={config.description}
               tokenName={config.tokenName}
               tokenDescription={config.example}
-              onClick={function (tokenName: string, color: string): void {
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/InformationForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/InformationForm/index.tsx
@@ -10,7 +10,7 @@ import {
 const LOADING_TIMEOUT = 1500;
 
 interface InformationFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
   withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
@@ -19,23 +19,23 @@ interface InformationFormProps {
 
 function InformationForm(props: InformationFormProps) {
   const {
-    currentAidBudgetUnits,
+    textConfig,
     handleSubmit,
     withSubmitButtons,
     onHasChanges,
     readOnly,
   } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const [infoText, setInfoText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
   const handleChangeInformation = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
+    setInfoText(aidBudgetUnits);
     if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
     if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
   };
@@ -44,7 +44,7 @@ function InformationForm(props: InformationFormProps) {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(infoText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +54,7 @@ function InformationForm(props: InformationFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setInfoText(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -70,8 +70,7 @@ function InformationForm(props: InformationFormProps) {
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
+      textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}

--- a/src/pages/people/outlets/texts/form/InformationForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/InformationForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { InformationFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,20 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface InformationFormProps {
   textConfig: any;
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  palette: typeof inube;
+  onChange: (event: any) => void;
+  handleSubmit: any;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function InformationForm(props: InformationFormProps) {
-  const {
-    textConfig,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
+  const { textConfig, handleSubmit, palette, onHasChanges, onChange } = props;
   const [infoText, setInfoText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -37,7 +31,7 @@ function InformationForm(props: InformationFormProps) {
   const handleChangeInformation = (aidBudgetUnits: IAssignmentFormEntry[]) => {
     setInfoText(aidBudgetUnits);
     if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+    handleSubmit(aidBudgetUnits);
   };
 
   const handleSubmitForm = () => {
@@ -66,15 +60,15 @@ function InformationForm(props: InformationFormProps) {
 
   return (
     <InformationFormUI
-      handleChangeInformation={handleChangeInformation}
+      handleChangeInformation={onChange}
       handleSubmitForm={handleSubmitForm}
+      palette={palette}
       handleReset={handleReset}
       isLoading={isLoading}
       textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
@@ -38,7 +38,7 @@ const renderMessage = (
 };
 
 interface InformationFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
@@ -52,39 +52,38 @@ interface InformationFormUIProps {
 
 function InformationFormUI(props: InformationFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
     handleChangeInformation,
-    withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
-  const informationConfig = Object.entries(textFormsConfig.info.status);
+
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
-        disabledButtons={false}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {informationConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}
               description={config.description}
               tokenName={config.tokenName}
               tokenDescription={config.example}
-              onClick={function (tokenName: string, color: string): void {
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
@@ -40,20 +40,20 @@ const renderMessage = (
 interface InformationFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeInformation: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  handleChangeInformation: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
 function InformationFormUI(props: InformationFormUIProps) {
   const {
     textConfig,
     isLoading,
+    palette,
     handleSubmitForm,
     handleReset,
     handleChangeInformation,
@@ -79,13 +79,15 @@ function InformationFormUI(props: InformationFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"information"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeInformation("information", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/LightForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/LightForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { LightFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,12 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface LightFormProps {
   textConfig: any;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (lightText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
 }
 
 function LightForm(props: LightFormProps) {
-  const { textConfig, handleSubmit, onHasChanges } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [lightText, setLightText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -58,9 +60,10 @@ function LightForm(props: LightFormProps) {
 
   return (
     <LightFormUI
-      handleChangeLight={handleChangeLight}
+      handleChangeLight={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
+      palette={palette}
       isLoading={isLoading}
       textConfig={textConfig}
       message={message}

--- a/src/pages/people/outlets/texts/form/LightForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/LightForm/index.tsx
@@ -10,41 +10,33 @@ import {
 const LOADING_TIMEOUT = 1500;
 
 interface LightFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  textConfig: any;
+  handleSubmit: (lightText: IAssignmentFormEntry[]) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function LightForm(props: LightFormProps) {
-  const {
-    currentAidBudgetUnits,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const { textConfig, handleSubmit, onHasChanges } = props;
+  const [lightText, setLightText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeLight = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeLight = (lightText: IAssignmentFormEntry[]) => {
+    setLightText(lightText);
+    if (onHasChanges) onHasChanges(hasChanges(lightText));
+    handleSubmit(lightText);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(lightText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +46,7 @@ function LightForm(props: LightFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setLightText(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -70,12 +62,10 @@ function LightForm(props: LightFormProps) {
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
+      textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/LightForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/LightForm/interface.tsx
@@ -40,9 +40,10 @@ const renderMessage = (
 interface LightFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeLight: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+  handleChangeLight: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
@@ -54,6 +55,7 @@ function LightFormUI(props: LightFormUIProps) {
     isLoading,
     handleSubmitForm,
     handleReset,
+    palette,
     handleChangeLight,
     message,
     onCloseSectionMessage,
@@ -77,13 +79,15 @@ function LightFormUI(props: LightFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"light"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeLight("light", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/LightForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/LightForm/interface.tsx
@@ -8,7 +8,6 @@ import {
   IMessageState,
 } from "@src/pages/privileges/outlets/users/types/forms.types";
 import { assignmentFormMessages } from "@src/pages/privileges/outlets/users/edit-user/config/messages.config";
-import { textFormsConfig } from "../../config/text.config";
 import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
 
 const renderMessage = (
@@ -39,53 +38,50 @@ const renderMessage = (
 };
 
 interface LightFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
   handleChangeLight: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
 }
 
 function LightFormUI(props: LightFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
     handleChangeLight,
-    withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
-  const lightConfig = Object.entries(textFormsConfig.light.status);
+
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
-        disabledButtons={false}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {lightConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}
               description={config.description}
               tokenName={config.tokenName}
               tokenDescription={config.example}
-              onClick={function (tokenName: string, color: string): void {
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
@@ -1,45 +1,45 @@
 import { useState } from "react";
 import { PrimaryFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
-import {
-  IAssignmentFormEntry,
-  IMessageState,
-} from "@src/pages/privileges/outlets/users/types/forms.types";
-import { textFormsConfig } from "../../config/text.config";
+import { IMessageState } from "@src/pages/privileges/outlets/users/types/forms.types";
 
 const LOADING_TIMEOUT = 1500;
 
 interface PrimaryFormProps {
   textConfig: any;
+  palette: typeof inube;
   handleSubmit: (textConfig: any) => void;
-  withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function PrimaryForm(props: PrimaryFormProps) {
-  const {
-    textConfig,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
+  const { textConfig, palette, handleSubmit, onHasChanges } = props;
   const [primaryText, setPrimaryText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedTokenName, setSelectedTokenName] = useState("");
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
+  });
+  const [tokenNames, setTokenNames] = useState(() => {
+    const initialNames: any = {};
+    Object.entries(textConfig.status).forEach(([key, config]: any) => {
+      initialNames[key] = config.tokenName;
+    });
+    return initialNames;
   });
 
   const hasChanges = (valueCompare: any) =>
     JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangePrimaryTokens = (textConfig: any) => {
-    setPrimaryText(textConfig);
-    if (onHasChanges) onHasChanges(hasChanges(textConfig));
-    if (!withSubmitButtons) handleSubmit(textConfig);
+  const handleChangePrimaryTokens = (key: string, tokenName: string) => {
+    setTokenNames((prevNames: any) => ({ ...prevNames, [key]: tokenName }));
   };
+  // const handleChangePrimaryTokens = (textConfig: any) => {
+  //   setPrimaryText(textConfig);
+  //   if (onHasChanges) onHasChanges(hasChanges(textConfig));
+  //   handleSubmit(textConfig);
+  // };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
@@ -67,16 +67,18 @@ function PrimaryForm(props: PrimaryFormProps) {
 
   return (
     <PrimaryFormUI
+      selectedTokenName={selectedTokenName}
+      tokenNames={tokenNames}
       handleChangePrimaryTokens={handleChangePrimaryTokens}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
       textConfig={textConfig}
+      palette={palette}
       withSubmitButtons
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
@@ -9,12 +9,13 @@ const LOADING_TIMEOUT = 1500;
 interface PrimaryFormProps {
   textConfig: any;
   palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (textConfig: any) => void;
   onHasChanges?: (hasChanges: boolean) => void;
 }
 
 function PrimaryForm(props: PrimaryFormProps) {
-  const { textConfig, palette, handleSubmit, onHasChanges } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [primaryText, setPrimaryText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedTokenName, setSelectedTokenName] = useState("");
@@ -31,15 +32,6 @@ function PrimaryForm(props: PrimaryFormProps) {
 
   const hasChanges = (valueCompare: any) =>
     JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
-
-  const handleChangePrimaryTokens = (key: string, tokenName: string) => {
-    setTokenNames((prevNames: any) => ({ ...prevNames, [key]: tokenName }));
-  };
-  // const handleChangePrimaryTokens = (textConfig: any) => {
-  //   setPrimaryText(textConfig);
-  //   if (onHasChanges) onHasChanges(hasChanges(textConfig));
-  //   handleSubmit(textConfig);
-  // };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
@@ -69,7 +61,7 @@ function PrimaryForm(props: PrimaryFormProps) {
     <PrimaryFormUI
       selectedTokenName={selectedTokenName}
       tokenNames={tokenNames}
-      handleChangePrimaryTokens={handleChangePrimaryTokens}
+      handleChangePrimaryTokens={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}

--- a/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/index.tsx
@@ -67,7 +67,6 @@ function PrimaryForm(props: PrimaryFormProps) {
       isLoading={isLoading}
       textConfig={textConfig}
       palette={palette}
-      withSubmitButtons
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}

--- a/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
@@ -34,23 +34,28 @@ const renderMessage = (
 
 interface PrimaryFormUIProps {
   textConfig: any;
+  tokenNames: any;
+  selectedTokenName: string;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangePrimaryTokens: (textConfig: any) => void;
+  handleChangePrimaryTokens: (tokenName: string, newColor: string) => void;
   withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: any) => boolean;
-  readOnly?: boolean;
 }
 
 function PrimaryFormUI(props: PrimaryFormUIProps) {
   const {
     textConfig,
+    tokenNames,
+    selectedTokenName,
     isLoading,
     handleSubmitForm,
     handleReset,
+    palette,
     handleChangePrimaryTokens,
     message,
     onCloseSectionMessage,
@@ -58,7 +63,6 @@ function PrimaryFormUI(props: PrimaryFormUIProps) {
   } = props;
 
   const colorCards = Object.entries(textConfig.status);
-
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
@@ -74,11 +78,15 @@ function PrimaryFormUI(props: PrimaryFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={() => {}}
+              appearance={"primary"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangePrimaryTokens(key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
@@ -40,7 +40,7 @@ interface PrimaryFormUIProps {
   palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangePrimaryTokens: (tokenName: string, newColor: string) => void;
+  handleChangePrimaryTokens: any;
   withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
@@ -85,7 +85,7 @@ function PrimaryFormUI(props: PrimaryFormUIProps) {
               category={key}
               textWithColorToken={config.example}
               onChange={(newTokenName) =>
-                handleChangePrimaryTokens(key, newTokenName)
+                handleChangePrimaryTokens("primary", key, newTokenName)
               }
             />
           ))}

--- a/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
@@ -41,7 +41,6 @@ interface PrimaryFormUIProps {
   handleSubmitForm: () => void;
   handleReset: () => void;
   handleChangePrimaryTokens: any;
-  withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: any) => boolean;
@@ -50,8 +49,6 @@ interface PrimaryFormUIProps {
 function PrimaryFormUI(props: PrimaryFormUIProps) {
   const {
     textConfig,
-    tokenNames,
-    selectedTokenName,
     isLoading,
     handleSubmitForm,
     handleReset,

--- a/src/pages/people/outlets/texts/form/SuccessForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/SuccessForm/index.tsx
@@ -9,42 +9,42 @@ import {
 
 const LOADING_TIMEOUT = 1500;
 
-interface AidBudgetsFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+interface SuccessTokensFormProps {
+  textConfig: any;
+  handleSubmit: (successTokens: IAssignmentFormEntry[]) => void;
   withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
   readOnly?: boolean;
 }
 
-function SuccessForm(props: AidBudgetsFormProps) {
+function SuccessForm(props: SuccessTokensFormProps) {
   const {
-    currentAidBudgetUnits,
+    textConfig,
     handleSubmit,
     withSubmitButtons,
     onHasChanges,
     readOnly,
   } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const [successTokens, setSuccessTokens] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeAidBudgets = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeSuccessTokens = (successTokens: IAssignmentFormEntry[]) => {
+    setSuccessTokens(successTokens);
+    if (onHasChanges) onHasChanges(hasChanges(successTokens));
+    if (!withSubmitButtons) handleSubmit(successTokens);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(successTokens);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +54,7 @@ function SuccessForm(props: AidBudgetsFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setSuccessTokens(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -66,11 +66,11 @@ function SuccessForm(props: AidBudgetsFormProps) {
 
   return (
     <SuccessFormUI
-      handleChangeAidBudgets={handleChangeAidBudgets}
+      handleChangeSuccessTokens={handleChangeSuccessTokens}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
+      textConfig={textConfig}
       withSubmitButtons={withSubmitButtons}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
@@ -80,5 +80,5 @@ function SuccessForm(props: AidBudgetsFormProps) {
   );
 }
 
-export type { AidBudgetsFormProps };
+export type { SuccessTokensFormProps };
 export { SuccessForm };

--- a/src/pages/people/outlets/texts/form/SuccessForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/SuccessForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { SuccessFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -12,19 +12,13 @@ const LOADING_TIMEOUT = 1500;
 interface SuccessTokensFormProps {
   textConfig: any;
   handleSubmit: (successTokens: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function SuccessForm(props: SuccessTokensFormProps) {
-  const {
-    textConfig,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
+  const { textConfig, handleSubmit, palette, onChange, onHasChanges } = props;
   const [successTokens, setSuccessTokens] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -37,7 +31,7 @@ function SuccessForm(props: SuccessTokensFormProps) {
   const handleChangeSuccessTokens = (successTokens: IAssignmentFormEntry[]) => {
     setSuccessTokens(successTokens);
     if (onHasChanges) onHasChanges(hasChanges(successTokens));
-    if (!withSubmitButtons) handleSubmit(successTokens);
+    handleSubmit(successTokens);
   };
 
   const handleSubmitForm = () => {
@@ -66,16 +60,15 @@ function SuccessForm(props: SuccessTokensFormProps) {
 
   return (
     <SuccessFormUI
-      handleChangeSuccessTokens={handleChangeSuccessTokens}
+      handleChangeSuccessTokens={onChange}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
+      palette={palette}
       isLoading={isLoading}
       textConfig={textConfig}
-      withSubmitButtons={withSubmitButtons}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
@@ -12,7 +12,7 @@ import { textFormsConfig } from "../../config/text.config";
 
 const renderMessage = (
   message: IMessageState,
-  onCloseSectionMessage: AidBudgetsFormUIProps["onCloseSectionMessage"]
+  onCloseSectionMessage: SuccessTokensFormUIProps["onCloseSectionMessage"]
 ) => {
   if (!message.visible || !message.type) {
     return null;
@@ -37,12 +37,12 @@ const renderMessage = (
   );
 };
 
-interface AidBudgetsFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+interface SuccessTokensFormUIProps {
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeAidBudgets: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+  handleChangeSuccessTokens: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
   withSubmitButtons?: boolean;
   message: IMessageState;
   onCloseSectionMessage: () => void;
@@ -50,40 +50,42 @@ interface AidBudgetsFormUIProps {
   readOnly?: boolean;
 }
 
-function SuccessFormUI(props: AidBudgetsFormUIProps) {
+function SuccessFormUI(props: SuccessTokensFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
-    handleChangeAidBudgets,
+    handleChangeSuccessTokens,
     withSubmitButtons,
     message,
     onCloseSectionMessage,
     hasChanges,
     readOnly,
   } = props;
-  const successConfig = Object.entries(textFormsConfig.success.status);
+
+  const colorCards = Object.entries(textConfig.status);
+
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
         {textFormsConfig.warning.description}
       </Text>
       <FormButtons
-        // disabledButtons={!hasChanges(textPrimaryConfig)}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {successConfig.map(([key, config]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
               title={config.title}
               description={config.description}
               tokenName={config.tokenName}
               tokenDescription={config.example}
-              onClick={function (tokenName: string, color: string): void {
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
@@ -40,14 +40,13 @@ const renderMessage = (
 interface SuccessTokensFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeSuccessTokens: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  handleChangeSuccessTokens: any;
   message: IMessageState;
   onCloseSectionMessage: () => void;
-  hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
-  readOnly?: boolean;
+  hasChanges: (valueCompare: any) => boolean;
 }
 
 function SuccessFormUI(props: SuccessTokensFormUIProps) {
@@ -57,11 +56,10 @@ function SuccessFormUI(props: SuccessTokensFormUIProps) {
     handleSubmitForm,
     handleReset,
     handleChangeSuccessTokens,
-    withSubmitButtons,
+    palette,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
 
   const colorCards = Object.entries(textConfig.status);
@@ -81,13 +79,15 @@ function SuccessFormUI(props: SuccessTokensFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"success"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeSuccessTokens("success", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/form/WarningForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/WarningForm/index.tsx
@@ -9,42 +9,42 @@ import {
 
 const LOADING_TIMEOUT = 1500;
 
-interface AidBudgetsFormProps {
-  currentAidBudgetUnits: IAssignmentFormEntry[];
-  handleSubmit: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
+interface WarningTokensFormProps {
+  textConfig: any;
+  handleSubmit: (warningText: IAssignmentFormEntry[]) => void;
   withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
   readOnly?: boolean;
 }
 
-function WarningForm(props: AidBudgetsFormProps) {
+function WarningForm(props: WarningTokensFormProps) {
   const {
-    currentAidBudgetUnits,
+    textConfig,
     handleSubmit,
     withSubmitButtons,
     onHasChanges,
     readOnly,
   } = props;
-  const [aidBudgetUnits, setAidBudgetUnits] = useState(currentAidBudgetUnits);
+  const [warningText, setWarningText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
     visible: false,
   });
 
   const hasChanges = (valueCompare: IAssignmentFormEntry[]) =>
-    JSON.stringify(currentAidBudgetUnits) !== JSON.stringify(valueCompare);
+    JSON.stringify(textConfig) !== JSON.stringify(valueCompare);
 
-  const handleChangeAidBudgets = (aidBudgetUnits: IAssignmentFormEntry[]) => {
-    setAidBudgetUnits(aidBudgetUnits);
-    if (onHasChanges) onHasChanges(hasChanges(aidBudgetUnits));
-    if (!withSubmitButtons) handleSubmit(aidBudgetUnits);
+  const handleChangeWarningTokens = (warningText: IAssignmentFormEntry[]) => {
+    setWarningText(warningText);
+    if (onHasChanges) onHasChanges(hasChanges(warningText));
+    if (!withSubmitButtons) handleSubmit(warningText);
   };
 
   const handleSubmitForm = () => {
     setIsLoading(true);
 
     setTimeout(() => {
-      handleSubmit(aidBudgetUnits);
+      handleSubmit(warningText);
       setIsLoading(false);
       setMessage({
         visible: true,
@@ -54,7 +54,7 @@ function WarningForm(props: AidBudgetsFormProps) {
   };
 
   const handleReset = () => {
-    setAidBudgetUnits(currentAidBudgetUnits);
+    setWarningText(textConfig);
     if (onHasChanges) onHasChanges(false);
   };
 
@@ -66,12 +66,11 @@ function WarningForm(props: AidBudgetsFormProps) {
 
   return (
     <WarningFormUI
-      handleChangeAidBudgets={handleChangeAidBudgets}
+      handleChangeWarningTokens={handleChangeWarningTokens}
       handleSubmitForm={handleSubmitForm}
       handleReset={handleReset}
       isLoading={isLoading}
-      aidBudgetUnits={aidBudgetUnits}
-      withSubmitButtons={withSubmitButtons}
+      textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
@@ -80,5 +79,5 @@ function WarningForm(props: AidBudgetsFormProps) {
   );
 }
 
-export type { AidBudgetsFormProps };
+export type { WarningTokensFormProps };
 export { WarningForm };

--- a/src/pages/people/outlets/texts/form/WarningForm/index.tsx
+++ b/src/pages/people/outlets/texts/form/WarningForm/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { WarningFormUI } from "./interface";
-
+import { inube } from "@inube/design-system";
 import { EMessageType } from "@src/types/messages.types";
 import {
   IAssignmentFormEntry,
@@ -11,20 +11,14 @@ const LOADING_TIMEOUT = 1500;
 
 interface WarningTokensFormProps {
   textConfig: any;
+  palette: typeof inube;
+  onChange: (event: any) => void;
   handleSubmit: (warningText: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
   onHasChanges?: (hasChanges: boolean) => void;
-  readOnly?: boolean;
 }
 
 function WarningForm(props: WarningTokensFormProps) {
-  const {
-    textConfig,
-    handleSubmit,
-    withSubmitButtons,
-    onHasChanges,
-    readOnly,
-  } = props;
+  const { textConfig, palette, handleSubmit, onChange, onHasChanges } = props;
   const [warningText, setWarningText] = useState(textConfig);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<IMessageState>({
@@ -37,7 +31,7 @@ function WarningForm(props: WarningTokensFormProps) {
   const handleChangeWarningTokens = (warningText: IAssignmentFormEntry[]) => {
     setWarningText(warningText);
     if (onHasChanges) onHasChanges(hasChanges(warningText));
-    if (!withSubmitButtons) handleSubmit(warningText);
+    handleSubmit(warningText);
   };
 
   const handleSubmitForm = () => {
@@ -66,15 +60,15 @@ function WarningForm(props: WarningTokensFormProps) {
 
   return (
     <WarningFormUI
-      handleChangeWarningTokens={handleChangeWarningTokens}
       handleSubmitForm={handleSubmitForm}
+      handleChangeWarningTokens={onChange}
       handleReset={handleReset}
       isLoading={isLoading}
       textConfig={textConfig}
       message={message}
       onCloseSectionMessage={handleCloseSectionMessage}
       hasChanges={hasChanges}
-      readOnly={readOnly}
+      palette={undefined}
     />
   );
 }

--- a/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
@@ -1,19 +1,15 @@
 import { FormButtons } from "@components/forms/submit/FormButtons";
-import { AssignmentForm } from "@components/forms/templates/AssignmentForm";
 import { SectionMessage, Stack, Text, inube } from "@inube/design-system";
 
 import { StyledMessageContainer } from "./styles";
 import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
-import {
-  IAssignmentFormEntry,
-  IMessageState,
-} from "@src/pages/privileges/outlets/users/types/forms.types";
+import { IMessageState } from "@src/pages/privileges/outlets/users/types/forms.types";
 import { assignmentFormMessages } from "@src/pages/privileges/outlets/users/edit-user/config/messages.config";
 import { textFormsConfig } from "../../config/text.config";
 
 const renderMessage = (
   message: IMessageState,
-  onCloseSectionMessage: AidBudgetsFormUIProps["onCloseSectionMessage"]
+  onCloseSectionMessage: WarningTokensFormUIProps["onCloseSectionMessage"]
 ) => {
   if (!message.visible || !message.type) {
     return null;
@@ -38,54 +34,52 @@ const renderMessage = (
   );
 };
 
-interface AidBudgetsFormUIProps {
-  aidBudgetUnits: IAssignmentFormEntry[];
+interface WarningTokensFormUIProps {
+  textConfig: any;
   isLoading: boolean;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeAidBudgets: (aidBudgetUnits: IAssignmentFormEntry[]) => void;
-  withSubmitButtons?: boolean;
+  handleChangeWarningTokens: (textConfig: any) => void;
   message: IMessageState;
   onCloseSectionMessage: () => void;
-  hasChanges: (valueCompare: IAssignmentFormEntry[]) => boolean;
+  hasChanges: (valueCompare: any) => boolean;
   readOnly?: boolean;
 }
 
-function WarningFormUI(props: AidBudgetsFormUIProps) {
+function WarningFormUI(props: WarningTokensFormUIProps) {
   const {
-    aidBudgetUnits,
+    textConfig,
     isLoading,
     handleSubmitForm,
     handleReset,
-    handleChangeAidBudgets,
-    withSubmitButtons,
+    handleChangeWarningTokens,
     message,
     onCloseSectionMessage,
     hasChanges,
-    readOnly,
   } = props;
-  const warningConfig = Object.entries(textFormsConfig.warning.status);
+
+  const colorCards = Object.entries(textConfig.status);
 
   return (
     <>
       <Text size="medium" padding="0px 0px 0px 0px" appearance="gray">
-        {textFormsConfig.warning.description}
+        {textConfig.description}
       </Text>
       <FormButtons
-        disabledButtons={false}
+        disabledButtons={!hasChanges(textConfig)}
         handleSubmit={handleSubmitForm}
         handleReset={handleReset}
         loading={isLoading}
       >
         <Stack direction="column" gap={inube.spacing.s350}>
-          {warningConfig.map(([key, primary]) => (
+          {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              title={primary.title}
-              description={primary.description}
-              tokenName={primary.tokenName}
-              tokenDescription={primary.example}
-              onClick={function (tokenName: string, color: string): void {
+              title={config.title}
+              description={config.description}
+              tokenName={config.tokenName}
+              tokenDescription={config.example}
+              onChange={function (tokenName: string, color: string): void {
                 throw new Error("Function not implemented.");
               }}
             />

--- a/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
@@ -6,6 +6,7 @@ import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
 import { IMessageState } from "@src/pages/privileges/outlets/users/types/forms.types";
 import { assignmentFormMessages } from "@src/pages/privileges/outlets/users/edit-user/config/messages.config";
 import { textFormsConfig } from "../../config/text.config";
+import { Appearance } from "@src/components/cards/FieldsetColorCard/types";
 
 const renderMessage = (
   message: IMessageState,
@@ -37,9 +38,14 @@ const renderMessage = (
 interface WarningTokensFormUIProps {
   textConfig: any;
   isLoading: boolean;
+  palette: typeof inube;
   handleSubmitForm: () => void;
   handleReset: () => void;
-  handleChangeWarningTokens: (textConfig: any) => void;
+  handleChangeWarningTokens: (
+    appearance: Appearance,
+    category: string,
+    tokenName: string
+  ) => void;
   message: IMessageState;
   onCloseSectionMessage: () => void;
   hasChanges: (valueCompare: any) => boolean;
@@ -50,6 +56,7 @@ function WarningFormUI(props: WarningTokensFormUIProps) {
   const {
     textConfig,
     isLoading,
+    palette,
     handleSubmitForm,
     handleReset,
     handleChangeWarningTokens,
@@ -75,13 +82,15 @@ function WarningFormUI(props: WarningTokensFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
+              palette={palette}
               title={config.title}
               description={config.description}
-              tokenName={config.tokenName}
-              tokenDescription={config.example}
-              onChange={function (tokenName: string, color: string): void {
-                throw new Error("Function not implemented.");
-              }}
+              appearance={"warning"}
+              category={key}
+              textWithColorToken={config.example}
+              onChange={(newTokenName) =>
+                handleChangeWarningTokens("warning", key, newTokenName)
+              }
             />
           ))}
         </Stack>

--- a/src/pages/people/outlets/texts/index.tsx
+++ b/src/pages/people/outlets/texts/index.tsx
@@ -8,12 +8,15 @@ import { privilegeUserTabsConfig } from "@src/pages/privileges/outlets/users/con
 import { IUsersMessage } from "@src/pages/privileges/outlets/users/types/users.types";
 import { colorTabsConfig } from "./config/colorTabs.config";
 import { textFormsConfig } from "./config/text.config";
+import { Appearance } from "@src/components/cards/FieldsetColorCard/types";
+import { getTokenColor } from "@src/components/cards/FieldsetColorCard/styles";
 
 function Texts() {
   const [isSelected, setIsSelected] = useState<string>();
   const [searchText, setSearchText] = useState("");
   const [showMenu, setShowMenu] = useState(false);
   const [selectedTab, setSelectedTab] = useState(colorTabsConfig.primary.id);
+  const [textConfig, setTextConfig] = useState(inube.color.text);
   const [message, setMessage] = useState<IUsersMessage>({
     visible: false,
   });
@@ -70,17 +73,24 @@ function Texts() {
   const handleTabChange = (tabId: string) => {
     setSelectedTab(tabId);
   };
-
-  // const handleCloseModal = () => {
-  //   setControlModal((prevControlModal) => ({
-  //     ...prevControlModal,
-  //     show: false,
-  //   }));
-  // };
-
   const handleContinueTab = () => {
     // setCurrentFormHasChanges(false);
     // setSelectedTab(controlModal.continueTab);
+  };
+
+  const handleTextConfigUpdate = (
+    appearance: Appearance,
+    category: string,
+    updatedTokenName: string
+  ) => {
+    const updatedTextConfig = { ...textConfig };
+    if (
+      updatedTextConfig[appearance] &&
+      updatedTextConfig[appearance][category]
+    ) {
+      updatedTextConfig[appearance][category] = getTokenColor(updatedTokenName);
+    }
+    setTextConfig(updatedTextConfig);
   };
 
   return (
@@ -88,6 +98,7 @@ function Texts() {
       textConfig={textFormsConfig}
       palette={inube.color.palette}
       selectedTab={selectedTab}
+      handleChangeColor={handleTextConfigUpdate}
       isSelected={isSelected || privilegeUserTabsConfig.privilegesUsers.id}
       searchText={searchText}
       handleTabChange={handleTabChange}

--- a/src/pages/people/outlets/texts/index.tsx
+++ b/src/pages/people/outlets/texts/index.tsx
@@ -1,7 +1,7 @@
 import { EMessageType } from "@src/types/messages.types";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-
+import { inube } from "@inube/design-system";
 import { TextsUI } from "./interface";
 import { finishAssistedMessagesConfig } from "@src/pages/privileges/outlets/users/complete-invitation/config/completeInvitation.config";
 import { privilegeUserTabsConfig } from "@src/pages/privileges/outlets/users/config/usersTabs.config";
@@ -86,6 +86,7 @@ function Texts() {
   return (
     <TextsUI
       textConfig={textFormsConfig}
+      palette={inube.color.palette}
       selectedTab={selectedTab}
       isSelected={isSelected || privilegeUserTabsConfig.privilegesUsers.id}
       searchText={searchText}

--- a/src/pages/people/outlets/texts/interface.tsx
+++ b/src/pages/people/outlets/texts/interface.tsx
@@ -58,6 +58,7 @@ interface UsersUIProps {
   selectedTab: string;
   isSelected: string;
   searchText: string;
+  handleChangeColor: any;
   handleTabChange: (id: string) => void;
   handleContinueTab: () => void;
   handleSearchText: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -73,6 +74,7 @@ export function TextsUI(props: UsersUIProps) {
     textConfig,
     // palette,
     selectedTab,
+    handleChangeColor,
     handleTabChange,
     message,
     handleCloseMessage,
@@ -118,6 +120,7 @@ export function TextsUI(props: UsersUIProps) {
                   <PrimaryForm
                     textConfig={textConfig.primary}
                     palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (textConfig: any): void {
                       throw new Error("Function not implemented.");
                     }}
@@ -126,6 +129,7 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.error.id && (
                   <ErrorForm
                     textConfig={textConfig.error}
+                    palette={palette}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {

--- a/src/pages/people/outlets/texts/interface.tsx
+++ b/src/pages/people/outlets/texts/interface.tsx
@@ -1,11 +1,9 @@
 import {
   Breadcrumbs,
-  Button,
-  Icon,
+  inube,
   SectionMessage,
   Stack,
   Tabs,
-  Textfield,
   useMediaQueries,
 } from "@inube/design-system";
 
@@ -18,10 +16,6 @@ import {
   StyledTabsContainer,
 } from "./styles";
 import { IUsersMessage } from "@src/pages/privileges/outlets/users/types/users.types";
-import { privilegeUserTabsConfig } from "@src/pages/privileges/outlets/users/config/usersTabs.config";
-import { menuInvitationLinks } from "@src/pages/privileges/outlets/users/config/menuInvitation.config";
-import { InvitationsTab } from "@src/pages/privileges/outlets/users/tabs/invitations";
-import { UsersTab } from "@src/pages/privileges/outlets/users/tabs/users";
 import { peopleOptionsConfig } from "../options/config/people.config";
 import { colorTabsConfig } from "./config/colorTabs.config";
 import { PrimaryForm } from "./form/PrimaryForm";
@@ -34,7 +28,7 @@ import { HelpForm } from "./form/HelpForm";
 import { DarkForm } from "./form/DarkForm";
 import { GrayForm } from "./form/GrayForm";
 import { LightForm } from "./form/LightForm";
-import { textFormsConfig } from "./config/text.config";
+import { useState } from "react";
 
 const renderMessage = (
   message: IUsersMessage,
@@ -60,6 +54,7 @@ const renderMessage = (
 
 interface UsersUIProps {
   textConfig: any;
+  palette: typeof inube;
   selectedTab: string;
   isSelected: string;
   searchText: string;
@@ -76,6 +71,7 @@ interface UsersUIProps {
 export function TextsUI(props: UsersUIProps) {
   const {
     textConfig,
+    // palette,
     selectedTab,
     handleTabChange,
     message,
@@ -84,6 +80,14 @@ export function TextsUI(props: UsersUIProps) {
 
   const { "(max-width: 580px)": smallScreen, "(max-width: 1073px)": typeTabs } =
     useMediaQueries(["(max-width: 580px)", "(max-width: 1073px)"]);
+  const [palette, setPalette] = useState(inube.color.palette);
+
+  // Function to update the palette
+  const handlePaletteChange = (tokenName: string | number, newColor: any) => {
+    const updatedPalette = { ...palette };
+    updatedPalette[tokenName] = newColor; // Update the color for the token
+    setPalette(updatedPalette); // Update the state
+  };
 
   return (
     <>
@@ -113,6 +117,7 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.primary.id && (
                   <PrimaryForm
                     textConfig={textConfig.primary}
+                    palette={palette}
                     handleSubmit={function (textConfig: any): void {
                       throw new Error("Function not implemented.");
                     }}
@@ -130,7 +135,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.warning.id && (
                   <WarningForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.warning}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -140,7 +145,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.success.id && (
                   <SuccessForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.success}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -150,7 +155,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.information.id && (
                   <InformationForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.info}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -160,7 +165,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.help.id && (
                   <HelpForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.help}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -170,7 +175,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.dark.id && (
                   <DarkForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.dark}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -180,7 +185,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.gray.id && (
                   <GrayForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.gray}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -190,7 +195,7 @@ export function TextsUI(props: UsersUIProps) {
                 )}
                 {selectedTab === colorTabsConfig.light.id && (
                   <LightForm
-                    currentAidBudgetUnits={[]}
+                    textConfig={textConfig.light}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {

--- a/src/pages/people/outlets/texts/interface.tsx
+++ b/src/pages/people/outlets/texts/interface.tsx
@@ -130,6 +130,7 @@ export function TextsUI(props: UsersUIProps) {
                   <ErrorForm
                     textConfig={textConfig.error}
                     palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -140,6 +141,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.warning.id && (
                   <WarningForm
                     textConfig={textConfig.warning}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -150,6 +153,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.success.id && (
                   <SuccessForm
                     textConfig={textConfig.success}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -160,6 +165,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.information.id && (
                   <InformationForm
                     textConfig={textConfig.info}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -170,6 +177,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.help.id && (
                   <HelpForm
                     textConfig={textConfig.help}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -180,6 +189,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.dark.id && (
                   <DarkForm
                     textConfig={textConfig.dark}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -190,6 +201,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.gray.id && (
                   <GrayForm
                     textConfig={textConfig.gray}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {
@@ -200,6 +213,8 @@ export function TextsUI(props: UsersUIProps) {
                 {selectedTab === colorTabsConfig.light.id && (
                   <LightForm
                     textConfig={textConfig.light}
+                    palette={palette}
+                    onChange={handleChangeColor}
                     handleSubmit={function (
                       aidBudgetUnits: IAssignmentFormEntry[]
                     ): void {


### PR DESCRIPTION
This pull request introduces a sophisticated menu for selecting palette color tokens within our app. This new feature aims to provide a seamless and intuitive interface for users to customize the color scheme of the app, enhancing both the aesthetic appeal and the user experience.