### PR TITLE
Create Menu for selecting palette color tokens

### DIFF
--- a/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
+++ b/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
@@ -67,8 +67,8 @@ Default.args = {
     "El texto tendrá este color cuando no tenga cambios por comportamiento o interacción con el usuario.",
   textWithColorToken:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tempor mauris a nisl auctor posuere. In eu metus dapibus, tristique felis sit amet, convallis ligula.",
-  appearance: "primary",
-  category: "regular",
+  appearance: "light",
+  category: "hover",
   palette: inube.color.palette,
 };
 

--- a/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
+++ b/src/components/cards/FieldsetColorCard/FieldsetColorCard.stories.tsx
@@ -67,9 +67,10 @@ Default.args = {
     "El texto tendrá este color cuando no tenga cambios por comportamiento o interacción con el usuario.",
   textWithColorToken:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tempor mauris a nisl auctor posuere. In eu metus dapibus, tristique felis sit amet, convallis ligula.",
-  appearance: "light",
+  typeToken: "text",
+  appearance: "primary",
   category: "hover",
-  palette: inube.color.palette,
+  optionsMenu: inube.color.palette,
 };
 
 export default story;

--- a/src/components/cards/FieldsetColorCard/index.tsx
+++ b/src/components/cards/FieldsetColorCard/index.tsx
@@ -16,16 +16,18 @@ interface FieldsetColorCardProps {
   description: string;
   appearance: Appearance;
   category: string;
-  textWithColorToken: string;
-  palette: typeof inube;
+  textWithColorToken?: string;
+  typeToken?: string;
+  optionsMenu: typeof inube;
   onChange: (tokenName: string) => void;
 }
 
 const getTokenReferenceFromAppearanceAndCategory = (
   appearance: Appearance,
+  typeToken: string,
   category: string
-) => {
-  const tokenReference = inube.color.text[appearance]?.[category];
+): string | null => {
+  const tokenReference = inube.color[typeToken]?.[appearance]?.[category];
   if (!tokenReference) return null;
   const castedPalette = inube.color.palette as Record<
     string,
@@ -48,12 +50,14 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
     appearance,
     category,
     textWithColorToken,
-    palette,
+    typeToken = "text",
+    optionsMenu,
     onChange,
   } = props;
 
   const tokenName = getTokenReferenceFromAppearanceAndCategory(
     appearance,
+    typeToken,
     category
   );
 
@@ -75,22 +79,24 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
               <TokenColorCard
                 tokenName={tokenName!}
                 type="tokenPicker"
-                palette={palette}
+                palette={optionsMenu}
                 onColorChange={handleColorChange}
               />
             </StyledTokenColorCardContainer>
-            <StyledTextWithTokenContainer isDark={isDark}>
-              <Stack padding="s100">
-                <Text
-                  size="medium"
-                  appearance={appearance}
-                  parentHover={category === "hover"}
-                  disabled={category === "disabled"}
-                >
-                  {textWithColorToken}
-                </Text>
-              </Stack>
-            </StyledTextWithTokenContainer>
+            {textWithColorToken && (
+              <StyledTextWithTokenContainer isDark={isDark}>
+                <Stack padding="s100">
+                  <Text
+                    size="medium"
+                    appearance={appearance}
+                    parentHover={category === "hover"}
+                    disabled={category === "disabled"}
+                  >
+                    {textWithColorToken}
+                  </Text>
+                </Stack>
+              </StyledTextWithTokenContainer>
+            )}
           </Stack>
         </Stack>
         <StyledPopupContainer id="palette"></StyledPopupContainer>

--- a/src/components/cards/FieldsetColorCard/index.tsx
+++ b/src/components/cards/FieldsetColorCard/index.tsx
@@ -1,9 +1,15 @@
 import { Stack, Text, inube } from "@inube/design-system";
 
-import { StyledTokenColorCardContainer, StyledPopupContainer } from "./styles";
+import {
+  StyledTokenColorCardContainer,
+  StyledPopupContainer,
+  StyledTextWithTokenContainer,
+  getTokenColor,
+} from "./styles";
 import { Fieldset } from "@src/components/inputs/Fieldset";
 import { TokenColorCard } from "../TokenColorCard";
 import { Appearance } from "./types";
+import tinycolor from "tinycolor2";
 
 interface FieldsetColorCardProps {
   title: string;
@@ -55,6 +61,8 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
     onChange(updatedTokenName);
   };
 
+  const isDark = tinycolor(getTokenColor(tokenName!)).isDark();
+
   return (
     <Fieldset title={title}>
       <>
@@ -63,7 +71,7 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
             {description}
           </Text>
           <Stack gap={inube.spacing.s200} alignItems="center">
-            <StyledTokenColorCardContainer>
+            <StyledTokenColorCardContainer isDark={isDark}>
               <TokenColorCard
                 tokenName={tokenName!}
                 type="tokenPicker"
@@ -71,14 +79,18 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
                 onColorChange={handleColorChange}
               />
             </StyledTokenColorCardContainer>
-            <Text
-              size="medium"
-              appearance={appearance}
-              parentHover={category === "hover"}
-              disabled={category === "disabled"}
-            >
-              {textWithColorToken}
-            </Text>
+            <StyledTextWithTokenContainer isDark={isDark}>
+              <Stack padding="s100">
+                <Text
+                  size="medium"
+                  appearance={appearance}
+                  parentHover={category === "hover"}
+                  disabled={category === "disabled"}
+                >
+                  {textWithColorToken}
+                </Text>
+              </Stack>
+            </StyledTextWithTokenContainer>
           </Stack>
         </Stack>
         <StyledPopupContainer id="palette"></StyledPopupContainer>

--- a/src/components/cards/FieldsetColorCard/styles.ts
+++ b/src/components/cards/FieldsetColorCard/styles.ts
@@ -2,11 +2,8 @@ import styled from "styled-components";
 import { inube } from "@inube/design-system";
 
 interface IStyledFieldsetColorCard {
-  tokenName: string;
-  tokenColor: string;
-  color: string;
-  isActive: boolean;
-  smallScreen: boolean;
+  isDark: boolean;
+  theme: typeof inube;
 }
 
 function getTokenColor(tokenName: string, theme?: typeof inube) {
@@ -18,13 +15,21 @@ function getTokenColor(tokenName: string, theme?: typeof inube) {
   }
 }
 
-const StyledTokenColorCardContainer = styled.div`
+const StyledTokenColorCardContainer = styled.div<IStyledFieldsetColorCard>`
   width: 100%;
   max-width: ${inube.spacing.s1000};
+
   & > div {
     width: 100%;
     height: 24px;
     max-width: 80px;
+
+    border: 1px solid
+      ${({ theme, isDark }) =>
+        !isDark
+          ? theme?.color?.stroke?.divider?.regular ||
+            inube.color.stroke.divider.regular
+          : "unset"};
     & > div {
       justify-content: center;
       padding: 4px;
@@ -41,4 +46,18 @@ const StyledPopupContainer = styled.div`
   }
 `;
 
-export { StyledTokenColorCardContainer, StyledPopupContainer, getTokenColor };
+const StyledTextWithTokenContainer = styled.div<IStyledFieldsetColorCard>`
+  & > div {
+    border-radius: ${inube.spacing.s100};
+    background-color: ${({ theme, isDark }) =>
+      !isDark
+        ? theme?.color?.text?.dark?.regular || inube.color.text.dark.regular
+        : "unset"};
+  }
+`;
+export {
+  StyledTokenColorCardContainer,
+  StyledPopupContainer,
+  StyledTextWithTokenContainer,
+  getTokenColor,
+};

--- a/src/components/cards/FieldsetColorCard/types.ts
+++ b/src/components/cards/FieldsetColorCard/types.ts
@@ -1,3 +1,4 @@
 import { inube } from "@inube/design-system";
 
 export type Appearance = keyof typeof inube.color.text;
+export type TypesToken = keyof typeof inube.color;

--- a/src/components/inputs/Fieldset/index.tsx
+++ b/src/components/inputs/Fieldset/index.tsx
@@ -13,7 +13,7 @@ function Fieldset(props: FieldsetProps) {
   return (
     <StyledFieldset>
       <legend>
-        <Stack gap="8px" padding="s050" alignItems="center">
+        <Stack padding="s050" alignItems="center">
           <Icon icon={icon} appearance="gray" />
           <Text type="title" size="small" appearance="gray">
             {title}

--- a/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/DarkForm/interface.tsx
@@ -79,7 +79,7 @@ function DarkFormUI(props: DarkFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"dark"}

--- a/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/ErrorForm/interface.tsx
@@ -85,7 +85,7 @@ function ErrorFormUI(props: ErrorTokensFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"error"}

--- a/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/GrayForm/interface.tsx
@@ -80,7 +80,7 @@ function GrayFormUI(props: GrayFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"gray"}

--- a/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/HelpForm/interface.tsx
@@ -80,7 +80,7 @@ function HelpFormUI(props: HelpFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"help"}

--- a/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/InformationForm/interface.tsx
@@ -79,7 +79,7 @@ function InformationFormUI(props: InformationFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"information"}

--- a/src/pages/people/outlets/texts/form/LightForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/LightForm/interface.tsx
@@ -79,7 +79,7 @@ function LightFormUI(props: LightFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"light"}

--- a/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/PrimaryForm/interface.tsx
@@ -75,7 +75,7 @@ function PrimaryFormUI(props: PrimaryFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"primary"}

--- a/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/SuccessForm/interface.tsx
@@ -79,7 +79,7 @@ function SuccessFormUI(props: SuccessTokensFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"success"}

--- a/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
+++ b/src/pages/people/outlets/texts/form/WarningForm/interface.tsx
@@ -82,7 +82,7 @@ function WarningFormUI(props: WarningTokensFormUIProps) {
           {colorCards.map(([key, config]: any) => (
             <FieldsetColorCard
               key={key}
-              palette={palette}
+              optionsMenu={palette}
               title={config.title}
               description={config.description}
               appearance={"warning"}


### PR DESCRIPTION
This pull request introduces a sophisticated menu for selecting palette color tokens within our app. This new feature aims to provide a seamless and intuitive interface for users to customize the color scheme of the app, enhancing both the aesthetic appeal and the user experience.