### PR TITLE
<Palette/> Neutral pallete layout should use two columns if text doesn't fit

### DIFF
--- a/src/components/cards/TokenColorCard/index.tsx
+++ b/src/components/cards/TokenColorCard/index.tsx
@@ -44,7 +44,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
       <Text
         type="title"
         size="medium"
-        padding="0px 0px 0px 0px"
+        padding="0px"
         textAlign="start"
         appearance="dark"
       >

--- a/src/components/cards/TokenColorCard/index.tsx
+++ b/src/components/cards/TokenColorCard/index.tsx
@@ -41,13 +41,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
 
   return categories.map(([category, tokens]: string) => (
     <Stack key={category} gap="16px" direction="column">
-      <Text
-        type="title"
-        size="medium"
-        padding="0px"
-        textAlign="start"
-        appearance="dark"
-      >
+      <Text type="title" size="medium" textAlign="start" appearance="dark">
         {categoryTranslations[category] || category}
       </Text>
       <StyledGridContainer hasBackground={hasBackground}>

--- a/src/pages/people/outlets/palette/interface.tsx
+++ b/src/pages/people/outlets/palette/interface.tsx
@@ -3,7 +3,7 @@ import {
   Grid,
   SectionMessage,
   Stack,
-  useMediaQuery,
+  useMediaQueries,
   inube,
   Text,
 } from "@inube/design-system";
@@ -117,8 +117,10 @@ export function PaletteUI(props: PaletteUIProps) {
     handleReset,
   } = props;
 
-  const smallScreen = useMediaQuery("(max-width: 640px)");
-  const midScreen = useMediaQuery("(max-width: 1170px)");
+  const {
+    "(max-width: 640px)": smallScreen,
+    "(max-width: 1170px)": midScreen,
+  } = useMediaQueries(["(max-width: 640px)", "(max-width: 1170px)"]);
   const paletteEntries = Object.entries(colorTokens);
   const firstTwoCategories = paletteEntries.slice(0, 2);
   const remainingCategories = paletteEntries.slice(2);

--- a/src/pages/people/outlets/palette/interface.tsx
+++ b/src/pages/people/outlets/palette/interface.tsx
@@ -76,13 +76,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
   } = props;
   return categories.map(([category, tokens]: string) => (
     <Stack key={category} gap="16px" direction="column">
-      <Text
-        type="title"
-        size="medium"
-        padding="0px"
-        textAlign="start"
-        appearance="dark"
-      >
+      <Text type="title" size="medium" textAlign="start" appearance="dark">
         {categoryTranslations[category] || category}
       </Text>
       <StyledGridContainer hasBackground={hasBackground}>

--- a/src/pages/people/outlets/palette/interface.tsx
+++ b/src/pages/people/outlets/palette/interface.tsx
@@ -79,7 +79,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
       <Text
         type="title"
         size="medium"
-        padding="0px 0px 0px 0px"
+        padding="0px"
         textAlign="start"
         appearance="dark"
       >
@@ -123,7 +123,8 @@ export function PaletteUI(props: PaletteUIProps) {
     handleReset,
   } = props;
 
-  const smallScreen = useMediaQuery("(max-width: 580px)");
+  const smallScreen = useMediaQuery("(max-width: 640px)");
+  const midScreen = useMediaQuery("(max-width: 1170px)");
   const paletteEntries = Object.entries(colorTokens);
   const firstTwoCategories = paletteEntries.slice(0, 2);
   const remainingCategories = paletteEntries.slice(2);
@@ -158,8 +159,10 @@ export function PaletteUI(props: PaletteUIProps) {
             >
               <RenderCategoryGrid
                 categories={firstTwoCategories}
-                templateColumns={smallScreen ? "auto" : "repeat(3, 1fr)"}
-                templateRows="repeat(7, 1fr)"
+                templateColumns={
+                  smallScreen ? "auto" : `repeat(${midScreen ? 2 : 3}, 1fr)`
+                }
+                templateRows={midScreen ? "repeat(10, 1fr)" : "repeat(7, 1fr)"}
                 autoFlow={smallScreen ? "row" : "column"}
                 hasBackground
                 handleColorChange={setColorTokens}


### PR DESCRIPTION
1) Replacing padding: "0px 0px 0px 0px" with padding: "0px" 
2) Adding new midSize boolean for widths under 1140px"
3) Adding new ternary selector for the number of columns
4) Adding new ternary selector for the number of rows (10 rows in the case of 2 columns based on figma mockups)


To fix: There is a duplicated RenderCategoyGrid component, used to render the palette outlet and used to render the tokenPicker in the tokenColorCard component, it is necessary a new file with this component. 