### PR TITLE
Change Success appearance buttons for Primary buttons in Privileges screens

### DIFF
--- a/src/components/feedback/DecisionModal/index.tsx
+++ b/src/components/feedback/DecisionModal/index.tsx
@@ -81,7 +81,7 @@ function DecisionModal(props: DecisionModalProps) {
               Cancel
             </Button>
             <Button
-              appearance={"success"}
+              appearance={"primary"}
               loading={isLoading}
               onClick={handleConfirmationClick}
               spacing={smallScreen ? "compact" : undefined}

--- a/src/pages/privileges/outlets/users/invite/interface.tsx
+++ b/src/pages/privileges/outlets/users/invite/interface.tsx
@@ -188,7 +188,7 @@ function InviteUI(props: InviteUIProps) {
             </Grid>
             <Button
               type="button"
-              appearance="success"
+              appearance="primary"
               iconBefore={<MdOutlineShortcut size={18} />}
               loading={loading}
               onClick={handleSubmit}


### PR DESCRIPTION
Change the appearence from "success" to "primary" after look for all of the cases that need this change.

Modifed components:
Componentes/feedback/DecisionModal
pages/privileges/outlets/users/invite