### PR TITLE
Unintended Horizontal Scroll on Palette

### DIFF
--- a/src/components/cards/FieldsetColorCard/index.tsx
+++ b/src/components/cards/FieldsetColorCard/index.tsx
@@ -1,6 +1,5 @@
 import { Stack, Text, inube } from "@inube/design-system";
 import { ThemeContext } from "styled-components";
-
 import {
   StyledTokenColorCardContainer,
   StyledTextWithTokenContainer,
@@ -90,35 +89,29 @@ function FieldsetColorCard(props: FieldsetColorCardProps) {
 
   return (
     <Fieldset title={title}>
-      <>
-        <Stack direction="column" gap={inube.spacing.s200}>
-          <Text size="medium" appearance="gray">
-            {description}
-          </Text>
-          <Stack gap={inube.spacing.s200} alignItems="center">
-            <StyledTokenColorCardContainer
-              requireBackground={requireBackground}
-            >
-              <TokenColorCard
-                tokenName={tokenName!}
-                type="tokenPicker"
-                palette={optionsMenu}
-                onColorChange={handleColorChange}
-                width="302px"
-                toggleActive={toggleActive}
-                setToggleActive={setToggleActive}
-              />
-            </StyledTokenColorCardContainer>
-            {children && (
-              <StyledTextWithTokenContainer
-                requireBackground={requireBackground}
-              >
-                <Stack padding="s100">{children}</Stack>
-              </StyledTextWithTokenContainer>
-            )}
-          </Stack>
+      <Stack direction="column" gap={inube.spacing.s200}>
+        <Text size="medium" appearance="gray">
+          {description}
+        </Text>
+        <Stack gap={inube.spacing.s200} alignItems="center">
+          <StyledTokenColorCardContainer requireBackground={requireBackground}>
+            <TokenColorCard
+              tokenName={tokenName!}
+              type="tokenPicker"
+              palette={optionsMenu}
+              onColorChange={handleColorChange}
+              width="302px"
+              toggleActive={toggleActive}
+              setToggleActive={setToggleActive}
+            />
+          </StyledTokenColorCardContainer>
+          {children && (
+            <StyledTextWithTokenContainer requireBackground={requireBackground}>
+              <Stack padding="s100">{children}</Stack>
+            </StyledTextWithTokenContainer>
+          )}
         </Stack>
-      </>
+      </Stack>
     </Fieldset>
   );
 }

--- a/src/components/cards/TokenColorCard/index.tsx
+++ b/src/components/cards/TokenColorCard/index.tsx
@@ -44,7 +44,7 @@ function RenderCategoryGrid(props: renderCategoryGridProps) {
     onChange,
   } = props;
 
-  const mobile = useMediaQuery("(max-width: 361px)");
+  const mobile = useMediaQuery("(max-width: 745px)");
 
   const width = mobile ? "280px" : "302px";
 

--- a/src/components/feedback/Popup/index.tsx
+++ b/src/components/feedback/Popup/index.tsx
@@ -9,10 +9,10 @@ const Popup = (props: PopupProps) => {
   const { "(max-width: 361px)": mobile, "(max-width: 755px)": tablet } =
     useMediaQueries(["(max-width: 361px)", "(max-width: 755px)"]);
 
-  const width = tablet ? "280px" : "302px";
-  const padding = tablet ? "s200 s200 s200 s200" : "s300 s300 s300 s300";
+  const width = tablet ? "284px" : "302px";
+  const padding = tablet ? "s200 s050 s200 s200" : "s300 s100 s300 s300";
   return (
-    <StyledPopup mobile={mobile}>
+    <StyledPopup mobile={mobile} tablet={tablet}>
       <Stack
         width={width}
         height="500px"

--- a/src/components/feedback/Popup/index.tsx
+++ b/src/components/feedback/Popup/index.tsx
@@ -1,15 +1,16 @@
 import { MdClear } from "react-icons/md";
-import { Stack, Text, Icon, useMediaQuery } from "@inube/design-system";
+import { Stack, Text, Icon, useMediaQueries } from "@inube/design-system";
 import { StyledPopup } from "./styles";
 import { PopupProps } from "./types";
 
 const Popup = (props: PopupProps) => {
   const { title, closeModal, children } = props;
 
-  const mobile = useMediaQuery("(max-width: 361px)");
+  const { "(max-width: 361px)": mobile, "(max-width: 755px)": tablet } =
+    useMediaQueries(["(max-width: 361px)", "(max-width: 755px)"]);
 
-  const width = mobile ? "280px" : "302px";
-  const padding = mobile ? "s200 s200 s200 s200" : "s300 s300 s300 s300";
+  const width = tablet ? "280px" : "302px";
+  const padding = tablet ? "s200 s200 s200 s200" : "s300 s300 s300 s300";
   return (
     <StyledPopup mobile={mobile}>
       <Stack

--- a/src/components/feedback/Popup/styles.ts
+++ b/src/components/feedback/Popup/styles.ts
@@ -4,6 +4,7 @@ import { inube } from "@inube/design-system";
 interface IStyledPopup {
   theme?: typeof inube;
   mobile?: boolean;
+  tablet?: boolean;
 }
 
 const StyledPopup = styled.div<IStyledPopup>`
@@ -21,6 +22,18 @@ const StyledPopup = styled.div<IStyledPopup>`
     top: 18px;
     div > div {
       overflow-x: hidden;
+      padding-right: ${({ tablet }: IStyledPopup) => (tablet ? "4px" : "8px")};
+    }
+    div::-webkit-scrollbar {
+      width: 8px;
+    }
+    div::-webkit-scrollbar-track-piece {
+      background-color: #ebecf0;
+    }
+    div::-webkit-scrollbar-thumb {
+      height: 154px;
+      width: 8px;
+      background-color: ${inube.color.palette.neutral.N50};
     }
   }
 `;

--- a/src/components/feedback/Popup/styles.ts
+++ b/src/components/feedback/Popup/styles.ts
@@ -19,6 +19,9 @@ const StyledPopup = styled.div<IStyledPopup>`
     z-index: 2;
     left: ${({ mobile }: IStyledPopup) => (mobile ? "-40px" : "-12px")};
     top: 18px;
+    div > div {
+      overflow-x: hidden;
+    }
   }
 `;
 


### PR DESCRIPTION
The size of the tokenColorCard and the container are the same, for instance, in the responsive behavior it currently works, but in the case of the desktop behavior the scroll in the y direction reduces the available space fot the tokenColorCard. 

Conclusion: The options to avoid the horizontal scroll are: (1) Manipulate the browser to place the scroll-y in the padding (it is necessary to evaluate different browsers), (2) Change the dimension for the tokenColorCard under the requirements in the wireframes (3) Avoid the scroll-x with its corresponding property in css. So, i bet on the option (3).

Due to the components affected i included in this branch the adjustments required in _**Adjustment of Popup Dimensions to Align with Tablet Display Specifications**_  by changing the breakpoints.