### PR TITLE
Mock surface token tab for `<Blanket />`

### DIFF
--- a/src/components/feedback/SendingInformation/index.tsx
+++ b/src/components/feedback/SendingInformation/index.tsx
@@ -118,7 +118,7 @@ const handleAgree = () => {
 
 interface ISendInformationMessageProps {
   appearance: Appearance;
-  buttonType: ButtonType;
+  buttonType?: ButtonType;
 }
 
 const SendInformationMessage = (props: ISendInformationMessageProps) => {

--- a/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/RenderContentFormSurfaceBlanket.stories.tsx
+++ b/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/RenderContentFormSurfaceBlanket.stories.tsx
@@ -1,0 +1,81 @@
+import { StoryFn } from "@storybook/react";
+import { BrowserRouter } from "react-router-dom";
+import { presente, Stack, inube } from "@inube/design-system";
+import {
+  RenderContentFormSurfaceBlanket,
+  RenderContentFormSurfaceBlanketProps,
+} from ".";
+
+const story = {
+  components: [RenderContentFormSurfaceBlanket],
+  title: "layouts/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+const themeMap = {
+  presente: presente,
+  inube: inube,
+};
+
+const surfaceFormsConfig = {
+  dark: {
+    description:
+      "Las superficies de tipo primario se utilizan en componentes que están relacionados a acciones principales o comunican relación a la marca.",
+    status: {
+      regular: {
+        title: "Regular",
+        description:
+          "La superficie tomará este color para resaltar acciones principales o el color de marca.",
+      },
+    },
+  },
+};
+
+const formType = Object.keys(surfaceFormsConfig);
+
+const Default = (args: RenderContentFormSurfaceBlanketProps) => {
+  const selectedTheme = themeMap[args.token as keyof typeof themeMap];
+
+  return (
+    <Stack padding="s300" direction="column" gap={selectedTheme.spacing.s400}>
+      <RenderContentFormSurfaceBlanket {...args} token={selectedTheme} />
+    </Stack>
+  );
+};
+
+Default.args = {
+  formType: formType,
+  handleSubmit: () => {},
+  token: "presente",
+  surfaceConfig: surfaceFormsConfig,
+};
+Default.argTypes = {
+  token: {
+    options: ["presente", "inube"],
+    control: { type: "select" },
+    description: "the theme that it be use to render",
+    table: {
+      defaultValue: { summary: "inube" },
+    },
+  },
+  formType: {
+    options: formType,
+    control: { type: "select" },
+    description: "the form that it'll be render",
+    table: {
+      defaultValue: { summary: "dark" },
+    },
+  },
+};
+export default story;
+
+export { Default };

--- a/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/index.tsx
+++ b/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/index.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { RenderContentFormSurfaceBlanketUI } from "./interface";
+import { IUsersMessage } from "@src/pages/privileges/outlets/users/types/users.types";
+import { inube } from "@inube/design-system";
+
+import { IHandleSubmitProps } from "@src/routes/people";
+import { Appearance } from "@src/components/feedback/SendingInformation/types";
+import { getTokenColor } from "@src/components/cards/TokenColorCard/styles";
+import {
+  surfaceFormsConfig,
+  surfaceMessagesConfig,
+} from "../../config/surface.config";
+
+interface RenderContentFormSurfaceBlanketProps {
+  formType: Appearance;
+  handleSubmit: (props: IHandleSubmitProps) => void;
+  surfaceConfig: typeof surfaceFormsConfig;
+  token: typeof inube;
+}
+
+function RenderContentFormSurfaceBlanket(
+  props: RenderContentFormSurfaceBlanketProps
+) {
+  const { formType, handleSubmit, surfaceConfig, token } = props;
+  const [surfaceToken, setSurfaceToken] = useState(
+    JSON.parse(JSON.stringify({ ...token.color.surface }))
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [showBlanket, setShowBlanket] = useState(false);
+  const [message, setMessage] = useState<IUsersMessage>({
+    visible: false,
+  });
+
+  const hasChanges = (): boolean => {
+    return JSON.stringify(token.color.surface) !== JSON.stringify(surfaceToken);
+  };
+
+  const handleTokenChange = (
+    appearance: Appearance | string,
+    category: string,
+    updatedTokenName: string
+  ) => {
+    let updatedSurfaceTokens = { ...surfaceToken };
+    updatedSurfaceTokens[appearance][category] = getTokenColor(
+      updatedTokenName,
+      token
+    );
+
+    setSurfaceToken(updatedSurfaceTokens);
+  };
+
+  const handleSubmitForm = () => {
+    setIsLoading(true);
+    new Promise((resolve, reject) => {
+      setTimeout(() => {
+        const isSuccess = true;
+        if (isSuccess) {
+          resolve("success");
+        } else {
+          reject("failed");
+        }
+      }, 2000);
+    })
+      .then((result) => {
+        if (result === "success") {
+          setMessage({
+            visible: true,
+            data: surfaceMessagesConfig.success,
+          });
+          handleSubmit({
+            domain: "color",
+            block: "surface",
+            tokenUpdate: surfaceToken,
+          });
+        }
+      })
+      .catch(() => {
+        setMessage({
+          visible: true,
+          data: surfaceMessagesConfig.failed,
+        });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  const handleCloseSectionMessage = () => {
+    setMessage({
+      visible: false,
+    });
+  };
+
+  const handleReset = () => {
+    setSurfaceToken(JSON.parse(JSON.stringify({ ...token.color.surface })));
+  };
+
+  const handleShowBlanket = () => {
+    setShowBlanket(!showBlanket);
+  };
+
+  const updatedTheme = {
+    ...token,
+    color: {
+      ...token.color,
+      surface: surfaceToken,
+    },
+  };
+
+  return (
+    <RenderContentFormSurfaceBlanketUI
+      formType={formType}
+      handleCloseMessage={handleCloseSectionMessage}
+      handleReset={handleReset}
+      handleSubmitForm={handleSubmitForm}
+      handleShowBlanket={handleShowBlanket}
+      handleTokenChange={handleTokenChange}
+      hasChanges={hasChanges}
+      isLoading={isLoading}
+      message={message}
+      showBlanket={showBlanket}
+      surfaceConfig={surfaceConfig}
+      updatedTheme={updatedTheme}
+    />
+  );
+}
+
+export { RenderContentFormSurfaceBlanket };
+export type { RenderContentFormSurfaceBlanketProps };

--- a/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/interface.tsx
+++ b/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/interface.tsx
@@ -1,0 +1,164 @@
+import { FormButtons } from "@components/forms/submit/FormButtons";
+import {
+  Button,
+  Blanket,
+  SectionMessage,
+  Stack,
+  Text,
+  inube,
+  Grid,
+  useMediaQueries,
+} from "@inube/design-system";
+import { StyledBackdropBlanket, StyledMessageContainer } from "./styles";
+import { IMessageState } from "@src/pages/privileges/outlets/users/types/forms.types";
+import { FieldsetColorCard } from "@src/components/cards/FieldsetColorCard";
+import { IUsersMessage } from "@src/pages/privileges/outlets/users/types/users.types";
+import { ThemeProvider } from "styled-components";
+import { Appearance } from "@src/components/feedback/SendingInformation/types";
+import { surfaceFormsConfig } from "../../config/surface.config";
+
+interface ISurfaceCardConfig {
+  title: string;
+  description: string;
+}
+const renderMessage = (
+  message: IUsersMessage,
+  handleCloseMessage: () => void,
+  onMessageClosed: () => void
+) => {
+  if (!message.data) return null;
+
+  const closeMessageAndExecuteCallback = () => {
+    handleCloseMessage();
+    onMessageClosed();
+  };
+
+  return (
+    <StyledMessageContainer>
+      <Stack justifyContent="flex-end" width="100%">
+        <SectionMessage
+          appearance={message.data.appearance}
+          closeSectionMessage={closeMessageAndExecuteCallback}
+          description={message.data.description}
+          duration={4000}
+          icon={message.data.icon}
+          title={message.data.title}
+        />
+      </Stack>
+    </StyledMessageContainer>
+  );
+};
+
+interface RenderContentFormSurfaceBlanketUIProps {
+  formType: Appearance | string;
+  handleCloseMessage: () => void;
+  handleReset: () => void;
+  handleSubmitForm: () => void;
+  handleShowBlanket: () => void;
+  handleTokenChange: (
+    appearance: Appearance | string,
+    category: string,
+    updatedTokenName: string
+  ) => void;
+  hasChanges: () => boolean;
+  isLoading: boolean;
+  message: IMessageState;
+  showBlanket: boolean;
+  surfaceConfig: typeof surfaceFormsConfig;
+  updatedTheme: typeof inube;
+}
+
+function RenderContentFormSurfaceBlanketUI(
+  props: RenderContentFormSurfaceBlanketUIProps
+) {
+  const {
+    formType,
+    handleCloseMessage,
+    handleReset,
+    handleSubmitForm,
+    handleShowBlanket,
+    handleTokenChange,
+    hasChanges,
+    isLoading,
+    message,
+    showBlanket,
+    surfaceConfig,
+    updatedTheme,
+  } = props;
+
+  const surfaceCards = Object.entries(
+    surfaceConfig[formType as keyof typeof surfaceConfig].status
+  );
+
+  const {
+    "(max-width: 744px)": isSmallScreen,
+    "(min-width: 745px) and (max-width: 1000px)": isMediumScreen,
+  } = useMediaQueries([
+    "(max-width: 744px)",
+    "(min-width: 745px) and (max-width: 1000px)",
+  ]);
+
+  const templateColumns = isSmallScreen
+    ? "repeat(1, 1fr)"
+    : isMediumScreen
+    ? "repeat(2, 1fr)"
+    : "repeat(3, 1fr)";
+
+  return (
+    <>
+      <Text size="medium" padding="0px" appearance="gray">
+        {surfaceConfig[formType as keyof typeof surfaceConfig].description}
+      </Text>
+
+      <FormButtons
+        disabledButtons={!hasChanges()}
+        handleSubmit={handleSubmitForm}
+        handleReset={handleReset}
+        loading={isLoading}
+      >
+        <ThemeProvider theme={updatedTheme}>
+          <Stack direction="column" gap={inube.spacing.s350}>
+            <Button
+              appereance="dark"
+              variant="outlined"
+              onClick={handleShowBlanket}
+            >
+              Mostrar Blanket
+            </Button>
+            {showBlanket && (
+              <Blanket>
+                <StyledBackdropBlanket onClick={() => handleShowBlanket()} />
+              </Blanket>
+            )}
+            <Grid
+              templateColumns={templateColumns}
+              gap="s350"
+              autoColumns="unset"
+              autoRows="unset"
+            >
+              {surfaceCards.map(
+                ([key, config]: [string, ISurfaceCardConfig]) => (
+                  <FieldsetColorCard
+                    key={key}
+                    optionsMenu={updatedTheme.color.palette}
+                    title={config.title}
+                    description={config.description}
+                    appearance={formType}
+                    category={key}
+                    typeToken="surface"
+                    onChange={(newTokenName) =>
+                      handleTokenChange(formType, key, newTokenName)
+                    }
+                  />
+                )
+              )}
+            </Grid>
+          </Stack>
+        </ThemeProvider>
+      </FormButtons>
+      {renderMessage(message, handleCloseMessage, handleReset)}
+    </>
+  );
+}
+
+export { RenderContentFormSurfaceBlanketUI };

--- a/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/styles.ts
+++ b/src/pages/people/outlets/surfaces/form/RenderContentFormSurfaceBlanket/styles.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const StyledMessageContainer = styled.div`
+  position: fixed;
+  bottom: 18px;
+  right: 75px;
+  z-index: 2;
+`;
+
+const StyledBackdropBlanket = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+`;
+
+export { StyledMessageContainer, StyledBackdropBlanket };

--- a/src/pages/people/outlets/surfaces/interface.tsx
+++ b/src/pages/people/outlets/surfaces/interface.tsx
@@ -14,6 +14,7 @@ import { RenderSurfaceContentForm } from "./form/RenderContentFormSurface";
 import { IHandleSubmitProps } from "@src/routes/people";
 import { surfaceFormsConfig } from "./config/surface.config";
 import { Appearance } from "@src/components/feedback/SendingInformation/types";
+import { RenderContentFormSurfaceBlanket } from "./form/RenderContentFormSurfaceBlanket";
 
 interface SurfaceUIProps {
   handleTabChange: (id: string) => void;
@@ -60,7 +61,16 @@ export function SurfacesUI(props: SurfaceUIProps) {
               />
               {colorTabs.map(
                 (formType) =>
-                  selectedTab === formType && (
+                  selectedTab === formType &&
+                  (formType === "blanket" ? (
+                    <RenderContentFormSurfaceBlanket
+                      formType={formType as Appearance}
+                      handleSubmit={handleSubmit}
+                      key={formType}
+                      surfaceConfig={surfaceConfig}
+                      token={token}
+                    />
+                  ) : (
                     <RenderSurfaceContentForm
                       formType={formType as Appearance}
                       handleSubmit={handleSubmit}
@@ -68,7 +78,7 @@ export function SurfacesUI(props: SurfaceUIProps) {
                       surfaceConfig={surfaceConfig}
                       token={token}
                     />
-                  )
+                  ))
               )}
             </Stack>
           </StyledTabsContainer>


### PR DESCRIPTION
This pull request introduces the implementation of a mock surface token tab specifically for the `<Blanket />` component in our application. The objective is to provide a dedicated interface for previewing and customizing surface tokens, enhancing the design process and user experience associated with the `<Blanket />` component.