### PR TITLE
Bug caso uso

### DIFF
--- a/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/index.tsx
+++ b/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/index.tsx
@@ -108,7 +108,11 @@ function AddingLinixUseCase() {
   }, [webOptions, csOptions]);
 
   useEffect(() => {
-    clientServerButtonMenuOption();
+    if (formData.generalInformation.values.k_Opcion) {
+      clientServerButtonMenuOption();
+    } else {
+      setCsOptionsButtons([]);
+    }
   }, [formData.generalInformation.values.k_Opcion]);
 
   useEffect(() => {
@@ -308,32 +312,12 @@ function AddingLinixUseCase() {
       ([, config]) => config.id === currentStep
     )?.[0];
     if (stepKey) {
+      setFormData((prevFormData: IFormAddLinixUseCase) => ({
+        ...prevFormData,
+        [stepKey]: { values: values, isValid: true },
+      }));
       if (stepKey === "generalInformation") {
-        const updatedData: IFormAddLinixUseCase = {
-          ...formData,
-        };
-        Object.assign(updatedData[stepKey].values, values);
-        Object.assign(
-          updatedData.webOptions.values,
-          formData.webOptions.values.map((option) =>
-            option.id === (values as IGeneralInformation).k_Funcio
-              ? { ...option, isActive: true }
-              : option
-          )
-        );
-        Object.assign(
-          updatedData.clientServerOptions.values,
-          formData.clientServerOptions.values.map((option) =>
-            option.id === (values as IGeneralInformation).k_Opcion
-              ? { ...option, isActive: true }
-              : option
-          )
-        );
-      } else {
-        setFormData((prevFormData: IFormAddLinixUseCase) => ({
-          ...prevFormData,
-          [stepKey]: { values: values },
-        }));
+        setCsOptionsButtons([]);
       }
     }
   };

--- a/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/index.tsx
+++ b/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/index.tsx
@@ -318,6 +318,26 @@ function AddingLinixUseCase() {
       }));
       if (stepKey === "generalInformation") {
         setCsOptionsButtons([]);
+        const updatedData: IFormAddLinixUseCase = {
+          ...formData,
+        };
+        Object.assign(updatedData[stepKey].values, values);
+        Object.assign(
+          updatedData.webOptions.values,
+          formData.webOptions.values.map((option) =>
+            option.id === (values as IGeneralInformation).k_Funcio
+              ? { ...option, isActive: true }
+              : option
+          )
+        );
+        Object.assign(
+          updatedData.clientServerOptions.values,
+          formData.clientServerOptions.values.map((option) =>
+            option.id === (values as IGeneralInformation).k_Opcion
+              ? { ...option, isActive: true }
+              : option
+          )
+        );
       }
     }
   };

--- a/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/interface.tsx
+++ b/src/pages/privileges/outlets/linixUseCase/adding-linix-use-case/interface.tsx
@@ -235,13 +235,17 @@ function AddingLinixUseCaseUI(props: AddingLinixUseCaseUIProps) {
                     handlePrevStep(prevStep);
                   }}
                   handleNext={() => {
-                    const nextStep =
+                    let nextStep = currentStep + 1;
+                    if (
                       currentStep ===
                       Object.values(stepsAddingLinixUseCase).length
-                        ? (handleToggleModal(), currentStep)
-                        : currentStep === 1 && csOptionsButtons.length === 0
-                        ? 3
-                        : currentStep + 1;
+                    ) {
+                      handleToggleModal();
+                      return;
+                    }
+                    if (currentStep === 1 && csOptionsButtons.length === 0) {
+                      nextStep = 3;
+                    }
                     handleNextStep(nextStep);
                   }}
                   titleButtonText={titleButtonTextAssited}


### PR DESCRIPTION
The Linix client server menu option button is not working properly because when I select a field and move forward and then return, it does not make the corresponding setting and does not put the data that is. An example is the Ah field that has no options and still gives me the 2nd step when it should skip it:

![image](https://github.com/user-attachments/assets/52562364-719f-4d72-9b59-73b106d12cf4)
![image](https://github.com/user-attachments/assets/95cc6543-fbd9-4206-855e-1b3e63f54a7b)
